### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR for catkin

### DIFF
--- a/trajopt_ext/CMakeLists.txt
+++ b/trajopt_ext/CMakeLists.txt
@@ -10,5 +10,5 @@ catkin_package(
   LIBRARIES HACD vhacd
 )
 
-set(CMAKE_COMMON_INC "${CMAKE_SOURCE_DIR}/vhacd/scripts/cmake_common.cmake")
+set(CMAKE_COMMON_INC "${CMAKE_CURRENT_SOURCE_DIR}/vhacd/scripts/cmake_common.cmake")
 add_subdirectory(vhacd)

--- a/trajopt_sco/CMakeLists.txt
+++ b/trajopt_sco/CMakeLists.txt
@@ -39,9 +39,9 @@ if (HAVE_BPMPD)
   add_executable(bpmpd_caller src/bpmpd_caller.cpp)
 
   if( CMAKE_SIZEOF_VOID_P EQUAL 8 ) # 64 bits
-        set(BPMPD_LIBRARY "${CMAKE_SOURCE_DIR}/3rdpartylib/bpmpd_linux64.a")
+        set(BPMPD_LIBRARY "${CMAKE_CURRENT_SOURCE_DIR}/3rdpartylib/bpmpd_linux64.a")
   else()
-        set(BPMPD_LIBRARY "${CMAKE_SOURCE_DIR}/3rdpartylib/bpmpd_linux32.a")
+        set(BPMPD_LIBRARY "${CMAKE_CURRENT_SOURCE_DIR}/3rdpartylib/bpmpd_linux32.a")
   endif()
 
   target_link_libraries(bpmpd_caller ${BPMPD_LIBRARY})


### PR DESCRIPTION
When using catkin, the CMAKE_SOURCE_DIR was being set to the workspace root. Using CMAKE_CURRENT_SOURCE_DIR fixes this problem.