### PR TITLE
Joint cost updates

### DIFF
--- a/trajopt/CMakeLists.txt
+++ b/trajopt/CMakeLists.txt
@@ -87,6 +87,9 @@ if (CATKIN_ENABLE_TESTING)
   add_rostest_gtest(${PROJECT_NAME}_planning_unit test/planning_unit.launch test/planning_unit.cpp)
   target_link_libraries(${PROJECT_NAME}_planning_unit ${PROJECT_NAME} ${Boost_SYSTEM_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${catkin_LIBRARIES})
 
+  add_rostest_gtest(${PROJECT_NAME}_costs_unit test/costs_unit.launch test/costs_unit.cpp)
+  target_link_libraries(${PROJECT_NAME}_costs_unit ${PROJECT_NAME} ${Boost_SYSTEM_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${catkin_LIBRARIES})
+
   add_rostest_gtest(${PROJECT_NAME}_cast_cost_unit test/cast_cost_unit.launch test/cast_cost_unit.cpp)
   target_link_libraries(${PROJECT_NAME}_cast_cost_unit ${PROJECT_NAME} ${Boost_SYSTEM_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${catkin_LIBRARIES})
 

--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -265,8 +265,8 @@ struct JointPosTermInfo : public TermInfo, public MakesCost, public MakesConstra
 /**
 \brief Used to apply cost/constraint to joint-space velocity
 
-Term is applied to every step between first_step and last_step. It applies two limits, upper_limits/lower_limits, to the
-joint velocity subject to the following cases.
+Term is applied to every step between first_step and last_step (TODO). It applies two limits, upper_limits/lower_limits,
+to the joint velocity subject to the following cases.
 
 * term_type = TT_COST
 ** upper_limit=lower_limit - Cost is applied with a SQUARED error scaled by coeffs
@@ -277,6 +277,9 @@ joint velocity subject to the following cases.
 ** upper_limit!=lower_limit - 2 Inequality constraints are applied. That velocity < upper_limit and velocity >
 lower_limit
 
+Note: targs, upper_limits, and lower_limits are optional. If a term is not given it will default to 0 for all joints. If
+one value is given, this will be broadcast to all joints.
+
 \f{align*}{
   cost = \sum_{t=0}^{T-2} \sum_j c_j (x_{t+1,j} - x_{t,j})^2
 \f}
@@ -286,24 +289,21 @@ struct JointVelTermInfo : public TermInfo, public MakesCost, public MakesConstra
 {
   /** @brief Vector of coefficients that scales cost. */
   DblVec coeffs;
-  /** @brief Vector of velocity lower limits */
+  /** @brief Vector of velocity targets. Default: 0 */
   DblVec targs;
-  /** @brief Vector of velocity upper limits */
+  /** @brief Vector of velocity upper limits. Default: 0 */
   DblVec upper_tols;
-  /** @brief Vector of velocity lower limits */
+  /** @brief Vector of velocity lower limits. Default: 0 */
   DblVec lower_tols;
-  /** @brief First time step to which the term is applied */
+  /** @brief First time step to which the term is applied (TODO)*/
   int first_step;
-  /** @brief Last time step to which the term is applied */
+  /** @brief Last time step to which the term is applied (TODO) */
   int last_step;
   /** @brief Used to add term to pci from json */
   void fromJson(ProblemConstructionInfo& pci, const Json::Value& v);
   /** @brief Converts term info into cost/constraint and adds it to trajopt problem */
   void hatch(TrajOptProb& prob);
   DEFINE_CREATE(JointVelTermInfo)
-  private:
-      /** @brief Stores the degrees of freedom for checking parameter size on hatch */
-    unsigned int n_dof_;
 };
 
 /**

--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -132,6 +132,7 @@ struct TRAJOPT_API TermInfo
   static void RegisterMaker(const std::string& type, MakerFunc);
 
   virtual ~TermInfo() {}
+
 private:
   static std::map<std::string, MakerFunc> name2maker;
 };
@@ -264,6 +265,18 @@ struct JointPosTermInfo : public TermInfo, public MakesCost, public MakesConstra
 /**
 \brief Used to apply cost/constraint to joint-space velocity
 
+Term is applied to every step between first_step and last_step. It applies two limits, upper_limits/lower_limits, to the
+joint velocity subject to the following cases.
+
+* term_type = TT_COST
+** upper_limit=lower_limit - Cost is applied with a SQUARED error scaled by coeffs
+** upper_limit!=lower_limit - Cost is applied with a hinge error scaled by coeffs
+
+* term_type = TT_CNT
+** upper_limit=lower_limit - Equality constraint is applied
+** upper_limit!=lower_limit - 2 Inequality constraints are applied. That velocity < upper_limit and velocity >
+lower_limit
+
 \f{align*}{
   cost = \sum_{t=0}^{T-2} \sum_j c_j (x_{t+1,j} - x_{t,j})^2
 \f}
@@ -355,4 +368,4 @@ struct CollisionTermInfo : public TermInfo, public MakesCost
   DEFINE_CREATE(CollisionTermInfo)
 };
 
-}
+}  // namespace trajopt

--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -284,8 +284,14 @@ where j indexes over DOF, and \f$c_j\f$ are the coeffs.
 */
 struct JointVelTermInfo : public TermInfo, public MakesCost, public MakesConstraint
 {
-  /** @brief For TT_COST: coefficient that scales cost. For TT_CNT: Velocity limit */
+  /** @brief Vector of coefficients that scales cost. */
   DblVec coeffs;
+  /** @brief Vector of velocity lower limits */
+  DblVec targs;
+  /** @brief Vector of velocity upper limits */
+  DblVec upper_tols;
+  /** @brief Vector of velocity lower limits */
+  DblVec lower_tols;
   /** @brief First time step to which the term is applied */
   int first_step;
   /** @brief Last time step to which the term is applied */
@@ -295,6 +301,9 @@ struct JointVelTermInfo : public TermInfo, public MakesCost, public MakesConstra
   /** @brief Converts term info into cost/constraint and adds it to trajopt problem */
   void hatch(TrajOptProb& prob);
   DEFINE_CREATE(JointVelTermInfo)
+  private:
+      /** @brief Stores the degrees of freedom for checking parameter size on hatch */
+    unsigned int n_dof_;
 };
 
 /**

--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -313,6 +313,12 @@ struct JointAccTermInfo : public TermInfo, public MakesCost, public MakesConstra
 {
   /** @brief For TT_COST: coefficient that scales cost. For TT_CNT: Acceleration limit*/
   DblVec coeffs;
+  /** @brief Vector of accel targets. Default: 0 */
+  DblVec targs;
+  /** @brief Vector of accel upper limits. Default: 0 */
+  DblVec upper_tols;
+  /** @brief Vector of accel lower limits. Default: 0 */
+  DblVec lower_tols;
   /** @brief First time step to which the term is applied */
   int first_step;
   /** @brief Last time step to which the term is applied */
@@ -331,6 +337,12 @@ struct JointJerkTermInfo : public TermInfo, public MakesCost, public MakesConstr
 {
   /** @brief For TT_COST: coefficient that scales cost. For TT_CNT: Jerk limit */
   DblVec coeffs;
+  /** @brief Vector of jerk targets. Default: 0 */
+  DblVec targs;
+  /** @brief Vector of jerk upper limits. Default: 0 */
+  DblVec upper_tols;
+  /** @brief Vector of jerk lower limits. Default: 0 */
+  DblVec lower_tols;
   /** @brief First time step to which the term is applied */
   int first_step;
   /** @brief Last time step to which the term is applied */

--- a/trajopt/include/trajopt/trajectory_costs.hpp
+++ b/trajopt/include/trajopt/trajectory_costs.hpp
@@ -91,10 +91,8 @@ private:
   int first_step_;
   /** @brief Last time step to which the term is applied */
   int last_step_;
-  /** @brief Stores the cost as an expression */
-  AffExpr expr_;
-  /** @brief Stores the cost as an expression */
-  AffExpr expr_neg_;
+  /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps*2 */
+  std::vector<AffExpr> expr_vec_;
 
   // TODO: Add getVars
 };
@@ -118,17 +116,14 @@ public:
   /** Sum of violations */
   double violation(const vector<double>& x);
 
-  //  VarVector getVars() { return VarVector(); }
-  // TODO: Figure out why we are using vararray instead of varvector, and should I convert between them?
-  // From looking at pos, it appears that array contains all of the vectors for all the joints (maybe timesteps too?)
-
+  //  TODO: VarVector getVars() { return VarVector(); }
 private:
   /** @brief The variables being optimized. Used to properly index the vector being optimized */
   VarArray vars_;
   /** @brief The coefficients used to weight the cost */
   VectorXd coeffs_;
-  /** @brief Stores the cost as an expression */
-  AffExpr expr_;
+  /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps */
+  std::vector<AffExpr> expr_vec_;
   /** @brief Vector of velocity targets */
   VectorXd targs_;
   /** @brief First time step to which the term is applied */
@@ -169,10 +164,9 @@ private:
   int first_step_;
   /** @brief Last time step to which the term is applied */
   int last_step_;
-  /** @brief Stores the cost as an expression */
-  AffExpr expr_;
-  /** @brief Stores the cost as an expression */
-  AffExpr expr_neg_;
+  /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps*2 */
+  std::vector<AffExpr> expr_vec_;
+
 
   // TODO: Add getVars
 };

--- a/trajopt/include/trajopt/trajectory_costs.hpp
+++ b/trajopt/include/trajopt/trajectory_costs.hpp
@@ -13,27 +13,27 @@ namespace trajopt
 class TRAJOPT_API JointPosCost : public sco::Cost
 {
 public:
-  JointPosCost(const VarVector& vars, const VectorXd& vals, const VectorXd& coeffs);
-  virtual ConvexObjectivePtr convex(const vector<double>& x, Model* model);
+  JointPosCost(const sco::VarVector& vars, const Eigen::VectorXd& vals, const Eigen::VectorXd& coeffs);
+  virtual sco::ConvexObjectivePtr convex(const DblVec& x, sco::Model* model);
   /** @brief Evaluate cost given the vector of values */
-  virtual double value(const vector<double>&);
+  virtual double value(const DblVec&);
 
 private:
   /** @brief The variables being optimized. Used to properly index the vector being optimized */
-  VarVector vars_;
+  sco::VarVector vars_;
   /** @brief The target values. Cost is applied to difference between current value and this one */
-  VectorXd vals_;
+  Eigen::VectorXd vals_;
   /** @brief The coefficients used to weight the cost */
-  VectorXd coeffs_;
+  Eigen::VectorXd coeffs_;
   /** @brief Stores the cost as an expression */
-  QuadExpr expr_;
+  sco::QuadExpr expr_;
 };
 
-class TRAJOPT_API JointVelCost : public sco::Cost
+class TRAJOPT_API JointVelEqCost : public sco::Cost
 {
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
-  JointVelEqCost(const VarArray& traj, const VectorXd& coeffs, const VectorXd& targs, int& first_step, int& last_step);
+  JointVelEqCost(const VarArray& traj, const Eigen::VectorXd& coeffs, const Eigen::VectorXd& targs, int& first_step, int& last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   virtual sco::ConvexObjectivePtr convex(const DblVec& x, sco::Model* model);
   /** @brief Numerically evaluate cost given the vector of values */
@@ -47,7 +47,7 @@ private:
   /** @brief Stores the cost as an expression */
   sco::QuadExpr expr_;
   /** @brief Vector of velocity targets */
-  VectorXd targs_;
+  Eigen::VectorXd targs_;
   /** @brief First time step to which the term is applied */
   int first_step_;
   /** @brief Last time step to which the term is applied */
@@ -60,72 +60,72 @@ private:
  * @brief The JointVelIneqCost class
  * Assumes that the target is ...
  */
-class TRAJOPT_API JointVelIneqCost : public Cost
+class TRAJOPT_API JointVelIneqCost : public sco::Cost
 {
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
   JointVelIneqCost(const VarArray& traj,
-                   const VectorXd& coeffs,
-                   const VectorXd& targs,
-                   const VectorXd& upper_limits,
-                   const VectorXd& lower_limits,
+                   const Eigen::VectorXd& coeffs,
+                   const Eigen::VectorXd& targs,
+                   const Eigen::VectorXd& upper_limits,
+                   const Eigen::VectorXd& lower_limits,
                    int& first_step,
                    int& last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
-  virtual ConvexObjectivePtr convex(const vector<double>& x, Model* model);
+  virtual sco::ConvexObjectivePtr convex(const DblVec& x, sco::Model* model);
   /** @brief Numerically evaluate cost given the vector of values */
-  virtual double value(const vector<double>&);
+  virtual double value(const DblVec&);
 
 private:
   /** @brief The variables being optimized. Used to properly index the vector being optimized */
   VarArray vars_;
   /** @brief The coefficients used to weight the cost */
-  VectorXd coeffs_;
+  Eigen::VectorXd coeffs_;
   /** @brief Vector of upper tolerances */
-  VectorXd upper_tols_;
+  Eigen::VectorXd upper_tols_;
   /** @brief Vector of lower tolerances */
-  VectorXd lower_tols_;
+  Eigen::VectorXd lower_tols_;
   /** @brief Vector of velocity targets */
-  VectorXd targs_;
+  Eigen::VectorXd targs_;
   /** @brief First time step to which the term is applied */
   int first_step_;
   /** @brief Last time step to which the term is applied */
   int last_step_;
   /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps*2 */
-  std::vector<AffExpr> expr_vec_;
+  std::vector<sco::AffExpr> expr_vec_;
 
   // TODO: Add getVars
 };
 
-class TRAJOPT_API JointVelEqConstraint : public EqConstraint
+class TRAJOPT_API JointVelEqConstraint : public sco::EqConstraint
 {
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
   JointVelEqConstraint(const VarArray& traj,
-                       const VectorXd& coeffs,
-                       const VectorXd& targs,
+                       const Eigen::VectorXd& coeffs,
+                       const Eigen::VectorXd& targs,
                        int& first_step,
                        int& last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
-  virtual ConvexConstraintsPtr convex(const vector<double>& x, Model* model);
+  virtual sco::ConvexConstraintsPtr convex(const DblVec& x, sco::Model* model);
   /** @brief Numerically evaluate cost given the vector of values */
-  virtual vector<double> value(const vector<double>&);
+  virtual DblVec value(const DblVec&);
   /** Calculate constraint violations (positive part for inequality constraint,
    * absolute value for inequality constraint)*/
-  vector<double> violations(const vector<double>& x);
+  DblVec violations(const DblVec& x);
   /** Sum of violations */
-  double violation(const vector<double>& x);
+  double violation(const DblVec& x);
 
   //  TODO: VarVector getVars() { return VarVector(); }
 private:
   /** @brief The variables being optimized. Used to properly index the vector being optimized */
   VarArray vars_;
   /** @brief The coefficients used to weight the cost */
-  VectorXd coeffs_;
+  Eigen::VectorXd coeffs_;
   /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps */
-  std::vector<AffExpr> expr_vec_;
+  std::vector<sco::AffExpr> expr_vec_;
   /** @brief Vector of velocity targets */
-  VectorXd targs_;
+  Eigen::VectorXd targs_;
   /** @brief First time step to which the term is applied */
   int first_step_;
   /** @brief Last time step to which the term is applied */
@@ -133,45 +133,45 @@ private:
 
 };
 
-class TRAJOPT_API JointVelIneqConstraint : public IneqConstraint
+class TRAJOPT_API JointVelIneqConstraint : public sco::IneqConstraint
 {
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
   JointVelIneqConstraint(const VarArray& traj,
-                         const VectorXd& coeffs,
-                         const VectorXd& targs,
-                         const VectorXd& upper_limits,
-                         const VectorXd& lower_limits,
+                         const Eigen::VectorXd& coeffs,
+                         const Eigen::VectorXd& targs,
+                         const Eigen::VectorXd& upper_limits,
+                         const Eigen::VectorXd& lower_limits,
                          int& first_step,
                          int& last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
-  virtual ConvexConstraintsPtr convex(const vector<double>& x, Model* model);
+  virtual sco::ConvexConstraintsPtr convex(const DblVec& x, sco::Model* model);
   /** @brief Numerically evaluate cost given the vector of values */
-  virtual vector<double> value(const vector<double>&);
+  virtual DblVec value(const DblVec&);
 
 private:
   /** @brief The variables being optimized. Used to properly index the vector being optimized */
   VarArray vars_;
   /** @brief The coefficients used to weight the cost */
-  VectorXd coeffs_;
+  Eigen::VectorXd coeffs_;
   /** @brief Vector of upper tolerances */
-  VectorXd upper_tols_;
+  Eigen::VectorXd upper_tols_;
   /** @brief Vector of lower tolerances */
-  VectorXd lower_tols_;
+  Eigen::VectorXd lower_tols_;
   /** @brief Vector of velocity targets */
-  VectorXd targs_;
+  Eigen::VectorXd targs_;
   /** @brief First time step to which the term is applied */
   int first_step_;
   /** @brief Last time step to which the term is applied */
   int last_step_;
   /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps*2 */
-  std::vector<AffExpr> expr_vec_;
+  std::vector<sco::AffExpr> expr_vec_;
 
 
   // TODO: Add getVars
 };
 
-class TRAJOPT_API JointAccCost : public Cost
+class TRAJOPT_API JointAccCost : public sco::Cost
 {
 public:
   JointAccCost(const VarArray& traj, const Eigen::VectorXd& coeffs);

--- a/trajopt/include/trajopt/trajectory_costs.hpp
+++ b/trajopt/include/trajopt/trajectory_costs.hpp
@@ -33,7 +33,7 @@ class TRAJOPT_API JointVelCost : public sco::Cost
 {
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
-  JointVelEqCost(const VarArray& traj, const VectorXd& coeffs, const VectorXd& targs);
+  JointVelEqCost(const VarArray& traj, const VectorXd& coeffs, const VectorXd& targs, int& first_step, int& last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   virtual sco::ConvexObjectivePtr convex(const DblVec& x, sco::Model* model);
   /** @brief Numerically evaluate cost given the vector of values */
@@ -48,6 +48,10 @@ private:
   sco::QuadExpr expr_;
   /** @brief Vector of velocity targets */
   VectorXd targs_;
+  /** @brief First time step to which the term is applied */
+  int first_step_;
+  /** @brief Last time step to which the term is applied */
+  int last_step_;
 
   // TODO: Add time steps
   // TODO: Add getVars
@@ -65,7 +69,9 @@ public:
                    const VectorXd& coeffs,
                    const VectorXd& targs,
                    const VectorXd& upper_limits,
-                   const VectorXd& lower_limits);
+                   const VectorXd& lower_limits,
+                   int& first_step,
+                   int& last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   virtual ConvexObjectivePtr convex(const vector<double>& x, Model* model);
   /** @brief Numerically evaluate cost given the vector of values */
@@ -82,6 +88,10 @@ private:
   VectorXd lower_tols_;
   /** @brief Vector of velocity targets */
   VectorXd targs_;
+  /** @brief First time step to which the term is applied */
+  int first_step_;
+  /** @brief Last time step to which the term is applied */
+  int last_step_;
   /** @brief Stores the cost as an expression */
   AffExpr expr_;
   /** @brief Stores the cost as an expression */
@@ -95,7 +105,11 @@ class TRAJOPT_API JointVelEqConstraint : public EqConstraint
 {
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
-  JointVelEqConstraint(const VarArray& traj, const VectorXd& coeffs, const VectorXd& targs);
+  JointVelEqConstraint(const VarArray& traj,
+                       const VectorXd& coeffs,
+                       const VectorXd& targs,
+                       int& first_step,
+                       int& last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   virtual ConvexConstraintsPtr convex(const vector<double>& x, Model* model);
   /** @brief Numerically evaluate cost given the vector of values */
@@ -106,8 +120,8 @@ public:
   /** Sum of violations */
   double violation(const vector<double>& x);
 
-//  VarVector getVars() { return VarVector(); }
-  //TODO: Figure out why we are using vararray instead of varvector, and should I convert between them?
+  //  VarVector getVars() { return VarVector(); }
+  // TODO: Figure out why we are using vararray instead of varvector, and should I convert between them?
   // From looking at pos, it appears that array contains all of the vectors for all the joints (maybe timesteps too?)
 
 private:
@@ -119,6 +133,10 @@ private:
   AffExpr expr_;
   /** @brief Vector of velocity targets */
   VectorXd targs_;
+  /** @brief First time step to which the term is applied */
+  int first_step_;
+  /** @brief Last time step to which the term is applied */
+  int last_step_;
 
   // TODO: Add time steps
 };
@@ -128,10 +146,12 @@ class TRAJOPT_API JointVelIneqConstraint : public IneqConstraint
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
   JointVelIneqConstraint(const VarArray& traj,
-                   const VectorXd& coeffs,
-                   const VectorXd& targs,
-                   const VectorXd& upper_limits,
-                   const VectorXd& lower_limits);
+                         const VectorXd& coeffs,
+                         const VectorXd& targs,
+                         const VectorXd& upper_limits,
+                         const VectorXd& lower_limits,
+                         int& first_step,
+                         int& last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   virtual ConvexConstraintsPtr convex(const vector<double>& x, Model* model);
   /** @brief Numerically evaluate cost given the vector of values */
@@ -148,6 +168,10 @@ private:
   VectorXd lower_tols_;
   /** @brief Vector of velocity targets */
   VectorXd targs_;
+  /** @brief First time step to which the term is applied */
+  int first_step_;
+  /** @brief Last time step to which the term is applied */
+  int last_step_;
   /** @brief Stores the cost as an expression */
   AffExpr expr_;
   /** @brief Stores the cost as an expression */

--- a/trajopt/include/trajopt/trajectory_costs.hpp
+++ b/trajopt/include/trajopt/trajectory_costs.hpp
@@ -13,14 +13,20 @@ namespace trajopt
 class TRAJOPT_API JointPosCost : public sco::Cost
 {
 public:
-  JointPosCost(const sco::VarVector& vars, const Eigen::VectorXd& vals, const Eigen::VectorXd& coeffs);
-  virtual sco::ConvexObjectivePtr convex(const DblVec& x, sco::Model* model);
-  virtual double value(const DblVec &);
+  JointPosCost(const VarVector& vars, const VectorXd& vals, const VectorXd& coeffs);
+  virtual ConvexObjectivePtr convex(const vector<double>& x, Model* model);
+  /** @brief Evaluate cost given the vector of values */
+  virtual double value(const vector<double>&);
 
 private:
-  sco::VarVector vars_;
-  Eigen::VectorXd vals_, coeffs_;
-  sco::QuadExpr expr_;
+  /** @brief The variables being optimized. Used to properly index the vector being optimized */
+  VarVector vars_;
+  /** @brief The target values. Cost is applied to difference between current value and this one */
+  VectorXd vals_;
+  /** @brief The coefficients used to weight the cost */
+  VectorXd coeffs_;
+  /** @brief Stores the cost as an expression */
+  QuadExpr expr_;
 };
 
 class TRAJOPT_API JointVelCost : public sco::Cost

--- a/trajopt/include/trajopt/trajectory_costs.hpp
+++ b/trajopt/include/trajopt/trajectory_costs.hpp
@@ -53,7 +53,6 @@ private:
   /** @brief Last time step to which the term is applied */
   int last_step_;
 
-  // TODO: Add time steps
   // TODO: Add getVars
 };
 
@@ -82,9 +81,9 @@ private:
   VarArray vars_;
   /** @brief The coefficients used to weight the cost */
   VectorXd coeffs_;
-  /** @brief Vector of velocity targets */
+  /** @brief Vector of upper tolerances */
   VectorXd upper_tols_;
-  /** @brief Vector of velocity targets */
+  /** @brief Vector of lower tolerances */
   VectorXd lower_tols_;
   /** @brief Vector of velocity targets */
   VectorXd targs_;
@@ -97,7 +96,6 @@ private:
   /** @brief Stores the cost as an expression */
   AffExpr expr_neg_;
 
-  // TODO: Add time steps
   // TODO: Add getVars
 };
 
@@ -138,7 +136,6 @@ private:
   /** @brief Last time step to which the term is applied */
   int last_step_;
 
-  // TODO: Add time steps
 };
 
 class TRAJOPT_API JointVelIneqConstraint : public IneqConstraint
@@ -162,9 +159,9 @@ private:
   VarArray vars_;
   /** @brief The coefficients used to weight the cost */
   VectorXd coeffs_;
-  /** @brief Vector of velocity targets */
+  /** @brief Vector of upper tolerances */
   VectorXd upper_tols_;
-  /** @brief Vector of velocity targets */
+  /** @brief Vector of lower tolerances */
   VectorXd lower_tols_;
   /** @brief Vector of velocity targets */
   VectorXd targs_;
@@ -177,7 +174,6 @@ private:
   /** @brief Stores the cost as an expression */
   AffExpr expr_neg_;
 
-  // TODO: Add time steps
   // TODO: Add getVars
 };
 

--- a/trajopt/include/trajopt/trajectory_costs.hpp
+++ b/trajopt/include/trajopt/trajectory_costs.hpp
@@ -35,12 +35,12 @@ public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
   JointVelEqCost(const VarArray& traj,
                  const Eigen::VectorXd& coeffs,
-                 const Eigen::VectorXd& targs,
+                 const Eigen::VectorXd& targets,
                  int& first_step,
                  int& last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   virtual sco::ConvexObjectivePtr convex(const DblVec& x, sco::Model* model);
-  /** @brief Numerically evaluate cost given the vector of values */
+  /** @brief Numerically evaluate cost given the vector of values using Eigen*/
   virtual double value(const DblVec&);
 
 private:
@@ -51,7 +51,7 @@ private:
   /** @brief Stores the cost as an expression */
   sco::QuadExpr expr_;
   /** @brief Vector of velocity targets */
-  Eigen::VectorXd targs_;
+  Eigen::VectorXd targets_;
   /** @brief First time step to which the term is applied */
   int first_step_;
   /** @brief Last time step to which the term is applied */
@@ -60,17 +60,13 @@ private:
   // TODO: Add getVars
 };
 
-/**
- * @brief The JointVelIneqCost class
- * Assumes that the target is ...
- */
 class TRAJOPT_API JointVelIneqCost : public sco::Cost
 {
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
   JointVelIneqCost(const VarArray& traj,
                    const Eigen::VectorXd& coeffs,
-                   const Eigen::VectorXd& targs,
+                   const Eigen::VectorXd& targets,
                    const Eigen::VectorXd& upper_limits,
                    const Eigen::VectorXd& lower_limits,
                    int& first_step,
@@ -90,7 +86,7 @@ private:
   /** @brief Vector of lower tolerances */
   Eigen::VectorXd lower_tols_;
   /** @brief Vector of velocity targets */
-  Eigen::VectorXd targs_;
+  Eigen::VectorXd targets_;
   /** @brief First time step to which the term is applied */
   int first_step_;
   /** @brief Last time step to which the term is applied */
@@ -107,7 +103,7 @@ public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
   JointVelEqConstraint(const VarArray& traj,
                        const Eigen::VectorXd& coeffs,
-                       const Eigen::VectorXd& targs,
+                       const Eigen::VectorXd& targets,
                        int& first_step,
                        int& last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
@@ -126,10 +122,10 @@ private:
   VarArray vars_;
   /** @brief The coefficients used to weight the cost */
   Eigen::VectorXd coeffs_;
-  /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps */
+  /** @brief Stores the costs as an expression. Will be length num_jnts*(num_timesteps-1) */
   std::vector<sco::AffExpr> expr_vec_;
   /** @brief Vector of velocity targets */
-  Eigen::VectorXd targs_;
+  Eigen::VectorXd targets_;
   /** @brief First time step to which the term is applied */
   int first_step_;
   /** @brief Last time step to which the term is applied */
@@ -142,7 +138,7 @@ public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
   JointVelIneqConstraint(const VarArray& traj,
                          const Eigen::VectorXd& coeffs,
-                         const Eigen::VectorXd& targs,
+                         const Eigen::VectorXd& targets,
                          const Eigen::VectorXd& upper_limits,
                          const Eigen::VectorXd& lower_limits,
                          int& first_step,
@@ -162,12 +158,12 @@ private:
   /** @brief Vector of lower tolerances */
   Eigen::VectorXd lower_tols_;
   /** @brief Vector of velocity targets */
-  Eigen::VectorXd targs_;
+  Eigen::VectorXd targets_;
   /** @brief First time step to which the term is applied */
   int first_step_;
   /** @brief Last time step to which the term is applied */
   int last_step_;
-  /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps*2 */
+  /** @brief Stores the costs as an expression. Will be length num_jnts*(num_timesteps-1)*2 */
   std::vector<sco::AffExpr> expr_vec_;
 
   // TODO: Add getVars
@@ -179,7 +175,7 @@ public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
   JointAccEqCost(const VarArray& traj,
                  const Eigen::VectorXd& coeffs,
-                 const Eigen::VectorXd& targs,
+                 const Eigen::VectorXd& targets,
                  int& first_step,
                  int& last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
@@ -195,7 +191,7 @@ private:
   /** @brief Stores the cost as an expression */
   sco::QuadExpr expr_;
   /** @brief Vector of velocity targets */
-  Eigen::VectorXd targs_;
+  Eigen::VectorXd targets_;
   /** @brief First time step to which the term is applied */
   int first_step_;
   /** @brief Last time step to which the term is applied */
@@ -210,7 +206,7 @@ public:
   /** @brief Forms error in a vector of AffExpr - independent of penalty type */
   JointAccIneqCost(const VarArray& traj,
                    const Eigen::VectorXd& coeffs,
-                   const Eigen::VectorXd& targs,
+                   const Eigen::VectorXd& targets,
                    const Eigen::VectorXd& upper_limits,
                    const Eigen::VectorXd& lower_limits,
                    int& first_step,
@@ -229,13 +225,13 @@ private:
   Eigen::VectorXd upper_tols_;
   /** @brief Vector of lower tolerances */
   Eigen::VectorXd lower_tols_;
-  /** @brief Vector of velocity targets */
-  Eigen::VectorXd targs_;
+  /** @brief Vector of acceleration targets */
+  Eigen::VectorXd targets_;
   /** @brief First time step to which the term is applied */
   int first_step_;
   /** @brief Last time step to which the term is applied */
   int last_step_;
-  /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps*2 */
+  /** @brief Stores the costs as an expression. Will be length num_jnts*(num_timesteps-2)*2 */
   std::vector<sco::AffExpr> expr_vec_;
 
   // TODO: Add getVars
@@ -247,7 +243,7 @@ public:
   /** @brief Forms error in a vector of AffExpr - independent of penalty type */
   JointAccEqConstraint(const VarArray& traj,
                        const Eigen::VectorXd& coeffs,
-                       const Eigen::VectorXd& targs,
+                       const Eigen::VectorXd& targets,
                        int& first_step,
                        int& last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
@@ -266,10 +262,10 @@ private:
   VarArray vars_;
   /** @brief The coefficients used to weight the cost */
   Eigen::VectorXd coeffs_;
-  /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps */
+  /** @brief Stores the costs as an expression. Will be length num_jnts*(num_timesteps-2) */
   std::vector<sco::AffExpr> expr_vec_;
-  /** @brief Vector of velocity targets */
-  Eigen::VectorXd targs_;
+  /** @brief Vector of acceleration targets */
+  Eigen::VectorXd targets_;
   /** @brief First time step to which the term is applied */
   int first_step_;
   /** @brief Last time step to which the term is applied */
@@ -282,7 +278,7 @@ public:
   /** @brief Forms error in a vector of AffExpr - independent of penalty type */
   JointAccIneqConstraint(const VarArray& traj,
                          const Eigen::VectorXd& coeffs,
-                         const Eigen::VectorXd& targs,
+                         const Eigen::VectorXd& targets,
                          const Eigen::VectorXd& upper_limits,
                          const Eigen::VectorXd& lower_limits,
                          int& first_step,
@@ -301,30 +297,25 @@ private:
   Eigen::VectorXd upper_tols_;
   /** @brief Vector of lower tolerances */
   Eigen::VectorXd lower_tols_;
-  /** @brief Vector of velocity targets */
-  Eigen::VectorXd targs_;
+  /** @brief Vector of acceleration targets */
+  Eigen::VectorXd targets_;
   /** @brief First time step to which the term is applied */
   int first_step_;
   /** @brief Last time step to which the term is applied */
   int last_step_;
-  /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps*2 */
+  /** @brief Stores the costs as an expression. Will be length num_jnts*(num_timesteps-2)*2 */
   std::vector<sco::AffExpr> expr_vec_;
 
   // TODO: Add getVars
 };
-/**
- * @brief The JointJerkEqCost class
- *
- *     Calculated with central finite difference. TODO: calc first/last 2 pnts using fwd/backward
- *      https://en.wikipedia.org/wiki/Finite_difference_coefficient
- */
+
 class TRAJOPT_API JointJerkEqCost : public sco::Cost
 {
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
   JointJerkEqCost(const VarArray& traj,
                   const Eigen::VectorXd& coeffs,
-                  const Eigen::VectorXd& targs,
+                  const Eigen::VectorXd& targets,
                   int& first_step,
                   int& last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
@@ -339,8 +330,8 @@ private:
   Eigen::VectorXd coeffs_;
   /** @brief Stores the cost as an expression */
   sco::QuadExpr expr_;
-  /** @brief Vector of velocity targets */
-  Eigen::VectorXd targs_;
+  /** @brief Vector of jerk targets */
+  Eigen::VectorXd targets_;
   /** @brief First time step to which the term is applied */
   int first_step_;
   /** @brief Last time step to which the term is applied */
@@ -355,7 +346,7 @@ public:
   /** @brief Forms error in a vector of AffExpr - independent of penalty type */
   JointJerkIneqCost(const VarArray& traj,
                     const Eigen::VectorXd& coeffs,
-                    const Eigen::VectorXd& targs,
+                    const Eigen::VectorXd& targets,
                     const Eigen::VectorXd& upper_limits,
                     const Eigen::VectorXd& lower_limits,
                     int& first_step,
@@ -374,13 +365,13 @@ private:
   Eigen::VectorXd upper_tols_;
   /** @brief Vector of lower tolerances */
   Eigen::VectorXd lower_tols_;
-  /** @brief Vector of velocity targets */
-  Eigen::VectorXd targs_;
+  /** @brief Vector of jerk targets */
+  Eigen::VectorXd targets_;
   /** @brief First time step to which the term is applied */
   int first_step_;
   /** @brief Last time step to which the term is applied */
   int last_step_;
-  /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps*2 */
+  /** @brief Stores the costs as an expression. Will be length num_jnts*(num_timesteps-4)*2 */
   std::vector<sco::AffExpr> expr_vec_;
 
   // TODO: Add getVars
@@ -392,7 +383,7 @@ public:
   /** @brief Forms error in a vector of AffExpr - independent of penalty type */
   JointJerkEqConstraint(const VarArray& traj,
                         const Eigen::VectorXd& coeffs,
-                        const Eigen::VectorXd& targs,
+                        const Eigen::VectorXd& targets,
                         int& first_step,
                         int& last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
@@ -411,10 +402,10 @@ private:
   VarArray vars_;
   /** @brief The coefficients used to weight the cost */
   Eigen::VectorXd coeffs_;
-  /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps */
+  /** @brief Stores the costs as an expression. Will be length num_jnts*(num_timesteps-4) */
   std::vector<sco::AffExpr> expr_vec_;
   /** @brief Vector of velocity targets */
-  Eigen::VectorXd targs_;
+  Eigen::VectorXd targets_;
   /** @brief First time step to which the term is applied */
   int first_step_;
   /** @brief Last time step to which the term is applied */
@@ -427,7 +418,7 @@ public:
   /** @brief Forms error in a vector of AffExpr - independent of penalty type */
   JointJerkIneqConstraint(const VarArray& traj,
                           const Eigen::VectorXd& coeffs,
-                          const Eigen::VectorXd& targs,
+                          const Eigen::VectorXd& targets,
                           const Eigen::VectorXd& upper_limits,
                           const Eigen::VectorXd& lower_limits,
                           int& first_step,
@@ -447,12 +438,12 @@ private:
   /** @brief Vector of lower tolerances */
   Eigen::VectorXd lower_tols_;
   /** @brief Vector of velocity targets */
-  Eigen::VectorXd targs_;
+  Eigen::VectorXd targets_;
   /** @brief First time step to which the term is applied */
   int first_step_;
   /** @brief Last time step to which the term is applied */
   int last_step_;
-  /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps*2 */
+  /** @brief Stores the costs as an expression. Will be length num_jnts*(num_timesteps-4)*2 */
   std::vector<sco::AffExpr> expr_vec_;
 
   // TODO: Add getVars

--- a/trajopt/include/trajopt/trajectory_costs.hpp
+++ b/trajopt/include/trajopt/trajectory_costs.hpp
@@ -33,7 +33,11 @@ class TRAJOPT_API JointVelEqCost : public sco::Cost
 {
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
-  JointVelEqCost(const VarArray& traj, const Eigen::VectorXd& coeffs, const Eigen::VectorXd& targs, int& first_step, int& last_step);
+  JointVelEqCost(const VarArray& traj,
+                 const Eigen::VectorXd& coeffs,
+                 const Eigen::VectorXd& targs,
+                 int& first_step,
+                 int& last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   virtual sco::ConvexObjectivePtr convex(const DblVec& x, sco::Model* model);
   /** @brief Numerically evaluate cost given the vector of values */
@@ -130,7 +134,6 @@ private:
   int first_step_;
   /** @brief Last time step to which the term is applied */
   int last_step_;
-
 };
 
 class TRAJOPT_API JointVelIneqConstraint : public sco::IneqConstraint
@@ -167,33 +170,291 @@ private:
   /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps*2 */
   std::vector<sco::AffExpr> expr_vec_;
 
+  // TODO: Add getVars
+};
+
+class TRAJOPT_API JointAccEqCost : public sco::Cost
+{
+public:
+  /** @brief Forms error in QuadExpr - independent of penalty type */
+  JointAccEqCost(const VarArray& traj,
+                 const Eigen::VectorXd& coeffs,
+                 const Eigen::VectorXd& targs,
+                 int& first_step,
+                 int& last_step);
+  /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
+  virtual sco::ConvexObjectivePtr convex(const DblVec& x, sco::Model* model);
+  /** @brief Numerically evaluate cost given the vector of values */
+  virtual double value(const DblVec&);
+
+private:
+  /** @brief The variables being optimized. Used to properly index the vector being optimized */
+  VarArray vars_;
+  /** @brief The coefficients used to weight the cost */
+  Eigen::VectorXd coeffs_;
+  /** @brief Stores the cost as an expression */
+  sco::QuadExpr expr_;
+  /** @brief Vector of velocity targets */
+  Eigen::VectorXd targs_;
+  /** @brief First time step to which the term is applied */
+  int first_step_;
+  /** @brief Last time step to which the term is applied */
+  int last_step_;
 
   // TODO: Add getVars
 };
 
-class TRAJOPT_API JointAccCost : public sco::Cost
+class TRAJOPT_API JointAccIneqCost : public sco::Cost
 {
 public:
-  JointAccCost(const VarArray& traj, const Eigen::VectorXd& coeffs);
+  /** @brief Forms error in a vector of AffExpr - independent of penalty type */
+  JointAccIneqCost(const VarArray& traj,
+                   const Eigen::VectorXd& coeffs,
+                   const Eigen::VectorXd& targs,
+                   const Eigen::VectorXd& upper_limits,
+                   const Eigen::VectorXd& lower_limits,
+                   int& first_step,
+                   int& last_step);
+  /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   virtual sco::ConvexObjectivePtr convex(const DblVec& x, sco::Model* model);
+  /** @brief Numerically evaluate cost given the vector of values */
   virtual double value(const DblVec&);
 
 private:
+  /** @brief The variables being optimized. Used to properly index the vector being optimized */
   VarArray vars_;
+  /** @brief The coefficients used to weight the cost */
   Eigen::VectorXd coeffs_;
-  sco::QuadExpr expr_;
+  /** @brief Vector of upper tolerances */
+  Eigen::VectorXd upper_tols_;
+  /** @brief Vector of lower tolerances */
+  Eigen::VectorXd lower_tols_;
+  /** @brief Vector of velocity targets */
+  Eigen::VectorXd targs_;
+  /** @brief First time step to which the term is applied */
+  int first_step_;
+  /** @brief Last time step to which the term is applied */
+  int last_step_;
+  /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps*2 */
+  std::vector<sco::AffExpr> expr_vec_;
+
+  // TODO: Add getVars
 };
 
-class TRAJOPT_API JointJerkCost : public sco::Cost
+class TRAJOPT_API JointAccEqConstraint : public sco::EqConstraint
 {
 public:
-  JointJerkCost(const VarArray& traj, const Eigen::VectorXd& coeffs);
+  /** @brief Forms error in a vector of AffExpr - independent of penalty type */
+  JointAccEqConstraint(const VarArray& traj,
+                       const Eigen::VectorXd& coeffs,
+                       const Eigen::VectorXd& targs,
+                       int& first_step,
+                       int& last_step);
+  /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
+  virtual sco::ConvexConstraintsPtr convex(const DblVec& x, sco::Model* model);
+  /** @brief Numerically evaluate cost given the vector of values */
+  virtual DblVec value(const DblVec&);
+  /** Calculate constraint violations (positive part for inequality constraint,
+   * absolute value for inequality constraint)*/
+  DblVec violations(const DblVec& x);
+  /** Sum of violations */
+  double violation(const DblVec& x);
+
+  //  TODO: VarVector getVars() { return VarVector(); }
+private:
+  /** @brief The variables being optimized. Used to properly index the vector being optimized */
+  VarArray vars_;
+  /** @brief The coefficients used to weight the cost */
+  Eigen::VectorXd coeffs_;
+  /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps */
+  std::vector<sco::AffExpr> expr_vec_;
+  /** @brief Vector of velocity targets */
+  Eigen::VectorXd targs_;
+  /** @brief First time step to which the term is applied */
+  int first_step_;
+  /** @brief Last time step to which the term is applied */
+  int last_step_;
+};
+
+class TRAJOPT_API JointAccIneqConstraint : public sco::IneqConstraint
+{
+public:
+  /** @brief Forms error in a vector of AffExpr - independent of penalty type */
+  JointAccIneqConstraint(const VarArray& traj,
+                         const Eigen::VectorXd& coeffs,
+                         const Eigen::VectorXd& targs,
+                         const Eigen::VectorXd& upper_limits,
+                         const Eigen::VectorXd& lower_limits,
+                         int& first_step,
+                         int& last_step);
+  /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
+  virtual sco::ConvexConstraintsPtr convex(const DblVec& x, sco::Model* model);
+  /** @brief Numerically evaluate cost given the vector of values */
+  virtual DblVec value(const DblVec&);
+
+private:
+  /** @brief The variables being optimized. Used to properly index the vector being optimized */
+  VarArray vars_;
+  /** @brief The coefficients used to weight the cost */
+  Eigen::VectorXd coeffs_;
+  /** @brief Vector of upper tolerances */
+  Eigen::VectorXd upper_tols_;
+  /** @brief Vector of lower tolerances */
+  Eigen::VectorXd lower_tols_;
+  /** @brief Vector of velocity targets */
+  Eigen::VectorXd targs_;
+  /** @brief First time step to which the term is applied */
+  int first_step_;
+  /** @brief Last time step to which the term is applied */
+  int last_step_;
+  /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps*2 */
+  std::vector<sco::AffExpr> expr_vec_;
+
+  // TODO: Add getVars
+};
+/**
+ * @brief The JointJerkEqCost class
+ *
+ *     Calculated with central finite difference. TODO: calc first/last 2 pnts using fwd/backward
+ *      https://en.wikipedia.org/wiki/Finite_difference_coefficient
+ */
+class TRAJOPT_API JointJerkEqCost : public sco::Cost
+{
+public:
+  /** @brief Forms error in QuadExpr - independent of penalty type */
+  JointJerkEqCost(const VarArray& traj,
+                  const Eigen::VectorXd& coeffs,
+                  const Eigen::VectorXd& targs,
+                  int& first_step,
+                  int& last_step);
+  /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   virtual sco::ConvexObjectivePtr convex(const DblVec& x, sco::Model* model);
+  /** @brief Numerically evaluate cost given the vector of values */
   virtual double value(const DblVec&);
 
 private:
+  /** @brief The variables being optimized. Used to properly index the vector being optimized */
   VarArray vars_;
+  /** @brief The coefficients used to weight the cost */
   Eigen::VectorXd coeffs_;
+  /** @brief Stores the cost as an expression */
   sco::QuadExpr expr_;
+  /** @brief Vector of velocity targets */
+  Eigen::VectorXd targs_;
+  /** @brief First time step to which the term is applied */
+  int first_step_;
+  /** @brief Last time step to which the term is applied */
+  int last_step_;
+
+  // TODO: Add getVars
+};
+
+class TRAJOPT_API JointJerkIneqCost : public sco::Cost
+{
+public:
+  /** @brief Forms error in a vector of AffExpr - independent of penalty type */
+  JointJerkIneqCost(const VarArray& traj,
+                    const Eigen::VectorXd& coeffs,
+                    const Eigen::VectorXd& targs,
+                    const Eigen::VectorXd& upper_limits,
+                    const Eigen::VectorXd& lower_limits,
+                    int& first_step,
+                    int& last_step);
+  /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
+  virtual sco::ConvexObjectivePtr convex(const DblVec& x, sco::Model* model);
+  /** @brief Numerically evaluate cost given the vector of values */
+  virtual double value(const DblVec&);
+
+private:
+  /** @brief The variables being optimized. Used to properly index the vector being optimized */
+  VarArray vars_;
+  /** @brief The coefficients used to weight the cost */
+  Eigen::VectorXd coeffs_;
+  /** @brief Vector of upper tolerances */
+  Eigen::VectorXd upper_tols_;
+  /** @brief Vector of lower tolerances */
+  Eigen::VectorXd lower_tols_;
+  /** @brief Vector of velocity targets */
+  Eigen::VectorXd targs_;
+  /** @brief First time step to which the term is applied */
+  int first_step_;
+  /** @brief Last time step to which the term is applied */
+  int last_step_;
+  /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps*2 */
+  std::vector<sco::AffExpr> expr_vec_;
+
+  // TODO: Add getVars
+};
+
+class TRAJOPT_API JointJerkEqConstraint : public sco::EqConstraint
+{
+public:
+  /** @brief Forms error in a vector of AffExpr - independent of penalty type */
+  JointJerkEqConstraint(const VarArray& traj,
+                        const Eigen::VectorXd& coeffs,
+                        const Eigen::VectorXd& targs,
+                        int& first_step,
+                        int& last_step);
+  /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
+  virtual sco::ConvexConstraintsPtr convex(const DblVec& x, sco::Model* model);
+  /** @brief Numerically evaluate cost given the vector of values */
+  virtual DblVec value(const DblVec&);
+  /** Calculate constraint violations (positive part for inequality constraint,
+   * absolute value for inequality constraint)*/
+  DblVec violations(const DblVec& x);
+  /** Sum of violations */
+  double violation(const DblVec& x);
+
+  //  TODO: VarVector getVars() { return VarVector(); }
+private:
+  /** @brief The variables being optimized. Used to properly index the vector being optimized */
+  VarArray vars_;
+  /** @brief The coefficients used to weight the cost */
+  Eigen::VectorXd coeffs_;
+  /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps */
+  std::vector<sco::AffExpr> expr_vec_;
+  /** @brief Vector of velocity targets */
+  Eigen::VectorXd targs_;
+  /** @brief First time step to which the term is applied */
+  int first_step_;
+  /** @brief Last time step to which the term is applied */
+  int last_step_;
+};
+
+class TRAJOPT_API JointJerkIneqConstraint : public sco::IneqConstraint
+{
+public:
+  /** @brief Forms error in a vector of AffExpr - independent of penalty type */
+  JointJerkIneqConstraint(const VarArray& traj,
+                          const Eigen::VectorXd& coeffs,
+                          const Eigen::VectorXd& targs,
+                          const Eigen::VectorXd& upper_limits,
+                          const Eigen::VectorXd& lower_limits,
+                          int& first_step,
+                          int& last_step);
+  /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
+  virtual sco::ConvexConstraintsPtr convex(const DblVec& x, sco::Model* model);
+  /** @brief Numerically evaluate cost given the vector of values */
+  virtual DblVec value(const DblVec&);
+
+private:
+  /** @brief The variables being optimized. Used to properly index the vector being optimized */
+  VarArray vars_;
+  /** @brief The coefficients used to weight the cost */
+  Eigen::VectorXd coeffs_;
+  /** @brief Vector of upper tolerances */
+  Eigen::VectorXd upper_tols_;
+  /** @brief Vector of lower tolerances */
+  Eigen::VectorXd lower_tols_;
+  /** @brief Vector of velocity targets */
+  Eigen::VectorXd targs_;
+  /** @brief First time step to which the term is applied */
+  int first_step_;
+  /** @brief Last time step to which the term is applied */
+  int last_step_;
+  /** @brief Stores the costs as an expression. Will be length num_jnts*num_timesteps*2 */
+  std::vector<sco::AffExpr> expr_vec_;
+
+  // TODO: Add getVars
 };
 }  // namespace trajopt

--- a/trajopt/include/trajopt/trajectory_costs.hpp
+++ b/trajopt/include/trajopt/trajectory_costs.hpp
@@ -48,6 +48,9 @@ private:
   sco::QuadExpr expr_;
   /** @brief Vector of velocity targets */
   VectorXd targs_;
+
+  // TODO: Add time steps
+  // TODO: Add getVars
 };
 
 /**
@@ -85,9 +88,72 @@ private:
   AffExpr expr_neg_;
 
   // TODO: Add time steps
+  // TODO: Add getVars
 };
 
-class TRAJOPT_API JointAccCost : public sco::Cost
+class TRAJOPT_API JointVelEqConstraint : public EqConstraint
+{
+public:
+  /** @brief Forms error in QuadExpr - independent of penalty type */
+  JointVelEqConstraint(const VarArray& traj, const VectorXd& coeffs, const VectorXd& targs);
+  /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
+  virtual ConvexConstraintsPtr convex(const vector<double>& x, Model* model);
+  /** @brief Numerically evaluate cost given the vector of values */
+  virtual vector<double> value(const vector<double>&);
+  /** Calculate constraint violations (positive part for inequality constraint,
+   * absolute value for inequality constraint)*/
+  vector<double> violations(const vector<double>& x);
+  /** Sum of violations */
+  double violation(const vector<double>& x);
+
+private:
+  /** @brief The variables being optimized. Used to properly index the vector being optimized */
+  VarArray vars_;
+  /** @brief The coefficients used to weight the cost */
+  VectorXd coeffs_;
+  /** @brief Stores the cost as an expression */
+  AffExpr expr_;
+  /** @brief Vector of velocity targets */
+  VectorXd targs_;
+
+  // TODO: Add time steps
+};
+
+class TRAJOPT_API JointVelIneqConstraint : public IneqConstraint
+{
+public:
+  /** @brief Forms error in QuadExpr - independent of penalty type */
+  JointVelIneqConstraint(const VarArray& traj,
+                   const VectorXd& coeffs,
+                   const VectorXd& targs,
+                   const VectorXd& upper_limits,
+                   const VectorXd& lower_limits);
+  /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
+  virtual ConvexConstraintsPtr convex(const vector<double>& x, Model* model);
+  /** @brief Numerically evaluate cost given the vector of values */
+  virtual vector<double> value(const vector<double>&);
+
+private:
+  /** @brief The variables being optimized. Used to properly index the vector being optimized */
+  VarArray vars_;
+  /** @brief The coefficients used to weight the cost */
+  VectorXd coeffs_;
+  /** @brief Vector of velocity targets */
+  VectorXd upper_tols_;
+  /** @brief Vector of velocity targets */
+  VectorXd lower_tols_;
+  /** @brief Vector of velocity targets */
+  VectorXd targs_;
+  /** @brief Stores the cost as an expression */
+  AffExpr expr_;
+  /** @brief Stores the cost as an expression */
+  AffExpr expr_neg_;
+
+  // TODO: Add time steps
+  // TODO: Add getVars
+};
+
+class TRAJOPT_API JointAccCost : public Cost
 {
 public:
   JointAccCost(const VarArray& traj, const Eigen::VectorXd& coeffs);

--- a/trajopt/include/trajopt/trajectory_costs.hpp
+++ b/trajopt/include/trajopt/trajectory_costs.hpp
@@ -106,6 +106,10 @@ public:
   /** Sum of violations */
   double violation(const vector<double>& x);
 
+//  VarVector getVars() { return VarVector(); }
+  //TODO: Figure out why we are using vararray instead of varvector, and should I convert between them?
+  // From looking at pos, it appears that array contains all of the vectors for all the joints (maybe timesteps too?)
+
 private:
   /** @brief The variables being optimized. Used to properly index the vector being optimized */
   VarArray vars_;

--- a/trajopt/include/trajopt/trajectory_costs.hpp
+++ b/trajopt/include/trajopt/trajectory_costs.hpp
@@ -32,14 +32,59 @@ private:
 class TRAJOPT_API JointVelCost : public sco::Cost
 {
 public:
-  JointVelCost(const VarArray& traj, const Eigen::VectorXd& coeffs);
+  /** @brief Forms error in QuadExpr - independent of penalty type */
+  JointVelEqCost(const VarArray& traj, const VectorXd& coeffs, const VectorXd& targs);
+  /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   virtual sco::ConvexObjectivePtr convex(const DblVec& x, sco::Model* model);
+  /** @brief Numerically evaluate cost given the vector of values */
   virtual double value(const DblVec&);
 
 private:
+  /** @brief The variables being optimized. Used to properly index the vector being optimized */
   VarArray vars_;
+  /** @brief The coefficients used to weight the cost */
   Eigen::VectorXd coeffs_;
+  /** @brief Stores the cost as an expression */
   sco::QuadExpr expr_;
+  /** @brief Vector of velocity targets */
+  VectorXd targs_;
+};
+
+/**
+ * @brief The JointVelIneqCost class
+ * Assumes that the target is ...
+ */
+class TRAJOPT_API JointVelIneqCost : public Cost
+{
+public:
+  /** @brief Forms error in QuadExpr - independent of penalty type */
+  JointVelIneqCost(const VarArray& traj,
+                   const VectorXd& coeffs,
+                   const VectorXd& targs,
+                   const VectorXd& upper_limits,
+                   const VectorXd& lower_limits);
+  /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
+  virtual ConvexObjectivePtr convex(const vector<double>& x, Model* model);
+  /** @brief Numerically evaluate cost given the vector of values */
+  virtual double value(const vector<double>&);
+
+private:
+  /** @brief The variables being optimized. Used to properly index the vector being optimized */
+  VarArray vars_;
+  /** @brief The coefficients used to weight the cost */
+  VectorXd coeffs_;
+  /** @brief Vector of velocity targets */
+  VectorXd upper_tols_;
+  /** @brief Vector of velocity targets */
+  VectorXd lower_tols_;
+  /** @brief Vector of velocity targets */
+  VectorXd targs_;
+  /** @brief Stores the cost as an expression */
+  AffExpr expr_;
+  /** @brief Stores the cost as an expression */
+  AffExpr expr_neg_;
+
+  // TODO: Add time steps
 };
 
 class TRAJOPT_API JointAccCost : public sco::Cost
@@ -67,4 +112,4 @@ private:
   Eigen::VectorXd coeffs_;
   sco::QuadExpr expr_;
 };
-}
+}  // namespace trajopt

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -629,13 +629,13 @@ void JointVelTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value&
   json_marshal::childFromJson(params, coeffs, "coeffs");
 
   // Optional Parameters
-  json_marshal::childFromJson(params, targs, "targs", DblVec(n_dof, 0));
+  json_marshal::childFromJson(params, targets, "targets", DblVec(n_dof, 0));
   json_marshal::childFromJson(params, upper_tols, "upper_tols", DblVec(n_dof, 0));
   json_marshal::childFromJson(params, lower_tols, "lower_tols", DblVec(n_dof, 0));
   json_marshal::childFromJson(params, first_step, "first_step", 0);
   json_marshal::childFromJson(params, last_step, "last_step", pci.basic_info.n_steps - 1);
 
-  const char* all_fields[] = { "coeffs", "first_step", "last_step", "targs", "lower_tols", "upper_tols" };
+  const char* all_fields[] = { "coeffs", "first_step", "last_step", "targets", "lower_tols", "upper_tols" };
   ensure_only_members(params, all_fields, sizeof(all_fields) / sizeof(char*));
 }
 
@@ -648,8 +648,8 @@ void JointVelTermInfo::hatch(TrajOptProb& prob)
   unsigned int n_dof = prob.GetKin()->getJointNames().size();
 
   // If target or tolerance is not given, set all to 0
-  if (targs.empty())
-    targs = DblVec(n_dof, 0);
+  if (targets.empty())
+    targets = DblVec(n_dof, 0);
   if (upper_tols.empty())
     upper_tols = DblVec(n_dof, 0);
   if (lower_tols.empty())
@@ -672,7 +672,7 @@ void JointVelTermInfo::hatch(TrajOptProb& prob)
 
   // Check if parameters are the correct size.
   checkParameterSize(coeffs, n_dof, "JointVelTermInfo coeffs", true);
-  checkParameterSize(targs, n_dof, "JointVelTermInfo upper_tols", true);
+  checkParameterSize(targets, n_dof, "JointVelTermInfo upper_tols", true);
   checkParameterSize(upper_tols, n_dof, "JointVelTermInfo upper_tols", true);
   checkParameterSize(lower_tols, n_dof, "JointVelTermInfo lower_tols", true);
 
@@ -688,14 +688,14 @@ void JointVelTermInfo::hatch(TrajOptProb& prob)
     if (is_upper_zeros && is_lower_zeros)
     {
       prob.addCost(sco::CostPtr(new JointVelEqCost(
-          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targs), first_step, last_step)));
+          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targets), first_step, last_step)));
       prob.getCosts().back()->setName(name);
     }
     else
     {
       prob.addCost(sco::CostPtr(new JointVelIneqCost(prob.GetVars(),
                                                      util::toVectorXd(coeffs),
-                                                     util::toVectorXd(targs),
+                                                     util::toVectorXd(targets),
                                                      util::toVectorXd(upper_tols),
                                                      util::toVectorXd(lower_tols),
                                                      first_step,
@@ -709,14 +709,14 @@ void JointVelTermInfo::hatch(TrajOptProb& prob)
     if (is_upper_zeros && is_lower_zeros)
     {
       prob.addConstraint(sco::ConstraintPtr(new JointVelEqConstraint(
-          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targs), first_step, last_step)));
+          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targets), first_step, last_step)));
       prob.getConstraints().back()->setName(name);
     }
     else
     {
       prob.addConstraint(sco::ConstraintPtr(new JointVelIneqConstraint(prob.GetVars(),
                                                                        util::toVectorXd(coeffs),
-                                                                       util::toVectorXd(targs),
+                                                                       util::toVectorXd(targets),
                                                                        util::toVectorXd(upper_tols),
                                                                        util::toVectorXd(lower_tols),
                                                                        first_step,
@@ -735,13 +735,13 @@ void JointAccTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value&
   json_marshal::childFromJson(params, coeffs, "coeffs");
 
   // Optional Parameters
-  json_marshal::childFromJson(params, targs, "targs", DblVec(n_dof, 0));
+  json_marshal::childFromJson(params, targets, "targets", DblVec(n_dof, 0));
   json_marshal::childFromJson(params, upper_tols, "upper_tols", DblVec(n_dof, 0));
   json_marshal::childFromJson(params, lower_tols, "lower_tols", DblVec(n_dof, 0));
   json_marshal::childFromJson(params, first_step, "first_step", 0);
   json_marshal::childFromJson(params, last_step, "last_step", pci.basic_info.n_steps - 1);
 
-  const char* all_fields[] = { "coeffs", "first_step", "last_step", "targs", "lower_tols", "upper_tols" };
+  const char* all_fields[] = { "coeffs", "first_step", "last_step", "targets", "lower_tols", "upper_tols" };
   ensure_only_members(params, all_fields, sizeof(all_fields) / sizeof(char*));
 }
 
@@ -754,8 +754,8 @@ void JointAccTermInfo::hatch(TrajOptProb& prob)
   unsigned int n_dof = prob.GetKin()->getJointNames().size();
 
   // If target or tolerance is not given, set all to 0
-  if (targs.empty())
-    targs = DblVec(n_dof, 0);
+  if (targets.empty())
+    targets = DblVec(n_dof, 0);
   if (upper_tols.empty())
     upper_tols = DblVec(n_dof, 0);
   if (lower_tols.empty())
@@ -779,7 +779,7 @@ void JointAccTermInfo::hatch(TrajOptProb& prob)
 
   // Check if parameters are the correct size.
   checkParameterSize(coeffs, n_dof, "JointAccTermInfo coeffs", true);
-  checkParameterSize(targs, n_dof, "JointAccTermInfo upper_tols", true);
+  checkParameterSize(targets, n_dof, "JointAccTermInfo upper_tols", true);
   checkParameterSize(upper_tols, n_dof, "JointAccTermInfo upper_tols", true);
   checkParameterSize(lower_tols, n_dof, "JointAccTermInfo lower_tols", true);
 
@@ -795,14 +795,14 @@ void JointAccTermInfo::hatch(TrajOptProb& prob)
     if (is_upper_zeros && is_lower_zeros)
     {
       prob.addCost(sco::CostPtr(new JointAccEqCost(
-          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targs), first_step, last_step)));
+          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targets), first_step, last_step)));
       prob.getCosts().back()->setName(name);
     }
     else
     {
       prob.addCost(sco::CostPtr(new JointAccIneqCost(prob.GetVars(),
                                                      util::toVectorXd(coeffs),
-                                                     util::toVectorXd(targs),
+                                                     util::toVectorXd(targets),
                                                      util::toVectorXd(upper_tols),
                                                      util::toVectorXd(lower_tols),
                                                      first_step,
@@ -816,14 +816,14 @@ void JointAccTermInfo::hatch(TrajOptProb& prob)
     if (is_upper_zeros && is_lower_zeros)
     {
       prob.addConstraint(sco::ConstraintPtr(new JointAccEqConstraint(
-          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targs), first_step, last_step)));
+          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targets), first_step, last_step)));
       prob.getConstraints().back()->setName(name);
     }
     else
     {
       prob.addConstraint(sco::ConstraintPtr(new JointAccIneqConstraint(prob.GetVars(),
                                                                        util::toVectorXd(coeffs),
-                                                                       util::toVectorXd(targs),
+                                                                       util::toVectorXd(targets),
                                                                        util::toVectorXd(upper_tols),
                                                                        util::toVectorXd(lower_tols),
                                                                        first_step,
@@ -842,13 +842,13 @@ void JointJerkTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value
   json_marshal::childFromJson(params, coeffs, "coeffs");
 
   // Optional Parameters
-  json_marshal::childFromJson(params, targs, "targs", DblVec(n_dof, 0));
+  json_marshal::childFromJson(params, targets, "targets", DblVec(n_dof, 0));
   json_marshal::childFromJson(params, upper_tols, "upper_tols", DblVec(n_dof, 0));
   json_marshal::childFromJson(params, lower_tols, "lower_tols", DblVec(n_dof, 0));
   json_marshal::childFromJson(params, first_step, "first_step", 0);
   json_marshal::childFromJson(params, last_step, "last_step", pci.basic_info.n_steps - 1);
 
-  const char* all_fields[] = { "coeffs", "first_step", "last_step", "targs", "lower_tols", "upper_tols" };
+  const char* all_fields[] = { "coeffs", "first_step", "last_step", "targets", "lower_tols", "upper_tols" };
   ensure_only_members(params, all_fields, sizeof(all_fields) / sizeof(char*));
 }
 
@@ -861,8 +861,8 @@ void JointJerkTermInfo::hatch(TrajOptProb& prob)
   unsigned int n_dof = prob.GetKin()->getJointNames().size();
 
   // If target or tolerance is not given, set all to 0
-  if (targs.empty())
-    targs = DblVec(n_dof, 0);
+  if (targets.empty())
+    targets = DblVec(n_dof, 0);
   if (upper_tols.empty())
     upper_tols = DblVec(n_dof, 0);
   if (lower_tols.empty())
@@ -886,7 +886,7 @@ void JointJerkTermInfo::hatch(TrajOptProb& prob)
 
   // Check if parameters are the correct size.
   checkParameterSize(coeffs, n_dof, "JointJerkTermInfo coeffs", true);
-  checkParameterSize(targs, n_dof, "JointJerkTermInfo upper_tols", true);
+  checkParameterSize(targets, n_dof, "JointJerkTermInfo upper_tols", true);
   checkParameterSize(upper_tols, n_dof, "JointJerkTermInfo upper_tols", true);
   checkParameterSize(lower_tols, n_dof, "JointJerkTermInfo lower_tols", true);
 
@@ -902,14 +902,14 @@ void JointJerkTermInfo::hatch(TrajOptProb& prob)
     if (is_upper_zeros && is_lower_zeros)
     {
       prob.addCost(sco::CostPtr(new JointJerkEqCost(
-          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targs), first_step, last_step)));
+          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targets), first_step, last_step)));
       prob.getCosts().back()->setName(name);
     }
     else
     {
       prob.addCost(sco::CostPtr(new JointJerkIneqCost(prob.GetVars(),
                                                       util::toVectorXd(coeffs),
-                                                      util::toVectorXd(targs),
+                                                      util::toVectorXd(targets),
                                                       util::toVectorXd(upper_tols),
                                                       util::toVectorXd(lower_tols),
                                                       first_step,
@@ -923,14 +923,14 @@ void JointJerkTermInfo::hatch(TrajOptProb& prob)
     if (is_upper_zeros && is_lower_zeros)
     {
       prob.addConstraint(sco::ConstraintPtr(new JointJerkEqConstraint(
-          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targs), first_step, last_step)));
+          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targets), first_step, last_step)));
       prob.getConstraints().back()->setName(name);
     }
     else
     {
       prob.addConstraint(sco::ConstraintPtr(new JointJerkIneqConstraint(prob.GetVars(),
                                                                         util::toVectorXd(coeffs),
-                                                                        util::toVectorXd(targs),
+                                                                        util::toVectorXd(targets),
                                                                         util::toVectorXd(upper_tols),
                                                                         util::toVectorXd(lower_tols),
                                                                         first_step,

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -11,6 +11,7 @@
 #include <trajopt_utils/eigen_conversions.hpp>
 #include <trajopt_utils/eigen_slicing.hpp>
 #include <trajopt_utils/logging.hpp>
+#include <trajopt_utils/vector_ops.hpp>
 #include <ros/ros.h>
 
 namespace
@@ -663,8 +664,8 @@ void JointVelTermInfo::hatch(TrajOptProb& prob)
   checkParameterSize(lower_tols, n_dof, "JointVelTermInfo lower_tols", true);
 
   // Check if tolerances are all zeros
-  bool is_upper_zeros = std::all_of(upper_tols.begin(), upper_tols.end(), [](int i) { return i == 0; });
-  bool is_lower_zeros = std::all_of(lower_tols.begin(), lower_tols.end(), [](int i) { return i == 0; });
+  bool is_upper_zeros = std::all_of(upper_tols.begin(), upper_tols.end(), [](double i) { return doubleEquals(i,0.); });
+  bool is_lower_zeros = std::all_of(lower_tols.begin(), lower_tols.end(), [](double i) { return doubleEquals(i,0.); });
 
   if (term_type == TT_COST)
   {

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -136,16 +136,20 @@ void ProblemConstructionInfo::readBasicInfo(const Json::Value& v)
 
 void ProblemConstructionInfo::readOptInfo(const Json::Value& v)
 {
-  json_marshal::childFromJson(v, opt_info.improve_ratio_threshold, "improve_ratio_threshold", opt_info.improve_ratio_threshold);
+  json_marshal::childFromJson(
+      v, opt_info.improve_ratio_threshold, "improve_ratio_threshold", opt_info.improve_ratio_threshold);
   json_marshal::childFromJson(v, opt_info.min_trust_box_size, "min_trust_box_size", opt_info.min_trust_box_size);
   json_marshal::childFromJson(v, opt_info.min_approx_improve, "min_approx_improve", opt_info.min_approx_improve);
-  json_marshal::childFromJson(v, opt_info.min_approx_improve_frac, "min_approx_improve_frac", opt_info.min_approx_improve_frac);
+  json_marshal::childFromJson(
+      v, opt_info.min_approx_improve_frac, "min_approx_improve_frac", opt_info.min_approx_improve_frac);
   json_marshal::childFromJson(v, opt_info.max_iter, "max_iter", opt_info.max_iter);
   json_marshal::childFromJson(v, opt_info.trust_shrink_ratio, "trust_shrink_ratio", opt_info.trust_shrink_ratio);
   json_marshal::childFromJson(v, opt_info.trust_expand_ratio, "trust_expand_ratio", opt_info.trust_expand_ratio);
   json_marshal::childFromJson(v, opt_info.cnt_tolerance, "cnt_tolerance", opt_info.cnt_tolerance);
-  json_marshal::childFromJson(v, opt_info.max_merit_coeff_increases, "max_merit_coeff_increases", opt_info.max_merit_coeff_increases);
-  json_marshal::childFromJson(v, opt_info.merit_coeff_increase_ratio, "merit_coeff_increase_ratio", opt_info.merit_coeff_increase_ratio);
+  json_marshal::childFromJson(
+      v, opt_info.max_merit_coeff_increases, "max_merit_coeff_increases", opt_info.max_merit_coeff_increases);
+  json_marshal::childFromJson(
+      v, opt_info.merit_coeff_increase_ratio, "merit_coeff_increase_ratio", opt_info.merit_coeff_increase_ratio);
   json_marshal::childFromJson(v, opt_info.max_time, "max_time", opt_info.max_time);
   json_marshal::childFromJson(v, opt_info.merit_error_coeff, "merit_error_coeff", opt_info.merit_error_coeff);
   json_marshal::childFromJson(v, opt_info.trust_box_size, "trust_box_size", opt_info.trust_box_size);
@@ -283,7 +287,8 @@ void ProblemConstructionInfo::fromJson(const Json::Value& v)
   }
 }
 
-TrajOptResult::TrajOptResult(sco::OptResults& opt, TrajOptProb& prob) : cost_vals(opt.cost_vals), cnt_viols(opt.cnt_viols)
+TrajOptResult::TrajOptResult(sco::OptResults& opt, TrajOptProb& prob)
+  : cost_vals(opt.cost_vals), cnt_viols(opt.cnt_viols)
 {
   for (const sco::CostPtr& cost : prob.getCosts())
   {
@@ -346,7 +351,9 @@ TrajOptProbPtr ConstructProblem(const ProblemConstructionInfo& pci)
     {
       for (int i = 1; i < prob->GetNumSteps(); ++i)
       {
-        prob->addLinearConstraint(sco::exprSub(sco::AffExpr(prob->m_traj_vars(i, dof_ind)), sco::AffExpr(prob->m_traj_vars(0, dof_ind))), sco::EQ);
+        prob->addLinearConstraint(
+            sco::exprSub(sco::AffExpr(prob->m_traj_vars(i, dof_ind)), sco::AffExpr(prob->m_traj_vars(0, dof_ind))),
+            sco::EQ);
       }
     }
   }
@@ -439,11 +446,13 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
   sco::VectorOfVectorPtr f(new DynamicCartPoseErrCalculator(target, prob.GetKin(), prob.GetEnv(), link, tcp));
   if (term_type == TT_COST)
   {
-    prob.addCost(sco::CostPtr(new TrajOptCostFromErrFunc(f, prob.GetVarRow(timestep), concat(rot_coeffs, pos_coeffs), sco::ABS, name)));
+    prob.addCost(sco::CostPtr(
+        new TrajOptCostFromErrFunc(f, prob.GetVarRow(timestep), concat(rot_coeffs, pos_coeffs), sco::ABS, name)));
   }
   else if (term_type == TT_CNT)
   {
-    prob.addConstraint(sco::ConstraintPtr(new TrajOptConstraintFromErrFunc(f, prob.GetVarRow(timestep), concat(rot_coeffs, pos_coeffs), sco::EQ, name)));
+    prob.addConstraint(sco::ConstraintPtr(
+        new TrajOptConstraintFromErrFunc(f, prob.GetVarRow(timestep), concat(rot_coeffs, pos_coeffs), sco::EQ, name)));
   }
   else
   {
@@ -498,11 +507,13 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
   sco::VectorOfVectorPtr f(new CartPoseErrCalculator(input_pose, prob.GetKin(), prob.GetEnv(), link, tcp));
   if (term_type == TT_COST)
   {
-    prob.addCost(sco::CostPtr(new TrajOptCostFromErrFunc(f, prob.GetVarRow(timestep), concat(rot_coeffs, pos_coeffs), sco::ABS, name)));
+    prob.addCost(sco::CostPtr(
+        new TrajOptCostFromErrFunc(f, prob.GetVarRow(timestep), concat(rot_coeffs, pos_coeffs), sco::ABS, name)));
   }
   else if (term_type == TT_CNT)
   {
-    prob.addConstraint(sco::ConstraintPtr(new TrajOptConstraintFromErrFunc(f, prob.GetVarRow(timestep), concat(rot_coeffs, pos_coeffs), sco::EQ, name)));
+    prob.addConstraint(sco::ConstraintPtr(
+        new TrajOptConstraintFromErrFunc(f, prob.GetVarRow(timestep), concat(rot_coeffs, pos_coeffs), sco::EQ, name)));
   }
   else
   {
@@ -590,7 +601,8 @@ void JointPosTermInfo::hatch(TrajOptProb& prob)
 {
   if (term_type == TT_COST)
   {
-    prob.addCost(sco::CostPtr(new JointPosCost(prob.GetVarRow(timestep), util::toVectorXd(vals), util::toVectorXd(coeffs))));
+    prob.addCost(
+        sco::CostPtr(new JointPosCost(prob.GetVarRow(timestep), util::toVectorXd(vals), util::toVectorXd(coeffs))));
     prob.getCosts().back()->setName(name);
   }
   else if (term_type == TT_CNT)
@@ -650,7 +662,8 @@ void JointVelTermInfo::hatch(TrajOptProb& prob)
     last_step = prob.GetNumSteps() - 1;
   if (last_step == first_step)
     last_step += 1;
-  if (last_step < first_step){
+  if (last_step < first_step)
+  {
     int tmp = first_step;
     first_step = last_step;
     last_step = tmp;
@@ -664,21 +677,29 @@ void JointVelTermInfo::hatch(TrajOptProb& prob)
   checkParameterSize(lower_tols, n_dof, "JointVelTermInfo lower_tols", true);
 
   // Check if tolerances are all zeros
-  bool is_upper_zeros = std::all_of(upper_tols.begin(), upper_tols.end(), [](double i) { return util::doubleEquals(i,0.); });
-  bool is_lower_zeros = std::all_of(lower_tols.begin(), lower_tols.end(), [](double i) { return util::doubleEquals(i,0.); });
+  bool is_upper_zeros =
+      std::all_of(upper_tols.begin(), upper_tols.end(), [](double i) { return util::doubleEquals(i, 0.); });
+  bool is_lower_zeros =
+      std::all_of(lower_tols.begin(), lower_tols.end(), [](double i) { return util::doubleEquals(i, 0.); });
 
   if (term_type == TT_COST)
   {
     // If the tolerances are 0, an equality cost is set. Otherwise it's a hinged "inequality" cost
     if (is_upper_zeros && is_lower_zeros)
     {
-      prob.addCost(sco::CostPtr(new JointVelEqCost(prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targs), first_step, last_step)));
+      prob.addCost(sco::CostPtr(new JointVelEqCost(
+          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targs), first_step, last_step)));
       prob.getCosts().back()->setName(name);
     }
     else
     {
-      prob.addCost(sco::CostPtr(new JointVelIneqCost(
-          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targs), util::toVectorXd(upper_tols), util::toVectorXd(lower_tols), first_step, last_step)));
+      prob.addCost(sco::CostPtr(new JointVelIneqCost(prob.GetVars(),
+                                                     util::toVectorXd(coeffs),
+                                                     util::toVectorXd(targs),
+                                                     util::toVectorXd(upper_tols),
+                                                     util::toVectorXd(lower_tols),
+                                                     first_step,
+                                                     last_step)));
       prob.getCosts().back()->setName(name);
     }
   }
@@ -687,14 +708,19 @@ void JointVelTermInfo::hatch(TrajOptProb& prob)
     // If the tolerances are 0, an equality cnt is set. Otherwise it's an inequality constraint
     if (is_upper_zeros && is_lower_zeros)
     {
-      prob.addConstraint(
-          sco::ConstraintPtr(new JointVelEqConstraint(prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targs), first_step, last_step)));
+      prob.addConstraint(sco::ConstraintPtr(new JointVelEqConstraint(
+          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targs), first_step, last_step)));
       prob.getConstraints().back()->setName(name);
     }
     else
     {
-      prob.addConstraint(sco::ConstraintPtr(new JointVelIneqConstraint(
-          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targs), util::toVectorXd(upper_tols), util::toVectorXd(lower_tols), first_step, last_step)));
+      prob.addConstraint(sco::ConstraintPtr(new JointVelIneqConstraint(prob.GetVars(),
+                                                                       util::toVectorXd(coeffs),
+                                                                       util::toVectorXd(targs),
+                                                                       util::toVectorXd(upper_tols),
+                                                                       util::toVectorXd(lower_tols),
+                                                                       first_step,
+                                                                       last_step)));
       prob.getConstraints().back()->setName(name);
     }
   }
@@ -705,42 +731,105 @@ void JointAccTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value&
   FAIL_IF_FALSE(v.isMember("params"));
   const Json::Value& params = v["params"];
 
+  unsigned int n_dof = pci.kin->numJoints();
   json_marshal::childFromJson(params, coeffs, "coeffs");
-  unsigned n_dof = pci.kin->numJoints();
-  if (coeffs.size() == 1)
-    coeffs = DblVec(n_dof, coeffs[0]);
-  else if (coeffs.size() != n_dof)
-  {
-    PRINT_AND_THROW(boost::format("wrong number of coeffs. expected %i got %i") % n_dof % coeffs.size());
-  }
 
-  const char* all_fields[] = { "coeffs" };
+  // Optional Parameters
+  json_marshal::childFromJson(params, targs, "targs", DblVec(n_dof, 0));
+  json_marshal::childFromJson(params, upper_tols, "upper_tols", DblVec(n_dof, 0));
+  json_marshal::childFromJson(params, lower_tols, "lower_tols", DblVec(n_dof, 0));
+  json_marshal::childFromJson(params, first_step, "first_step", 0);
+  json_marshal::childFromJson(params, last_step, "last_step", pci.basic_info.n_steps - 1);
+
+  const char* all_fields[] = { "coeffs", "first_step", "last_step", "targs", "lower_tols", "upper_tols" };
   ensure_only_members(params, all_fields, sizeof(all_fields) / sizeof(char*));
 }
 
 void JointAccTermInfo::hatch(TrajOptProb& prob)
 {
+  if ((term_type != TT_COST) && (term_type != TT_CNT))
+  {
+    ROS_WARN("JointAccTermInfo does not have a term_type defined. No cost/constraint applied");
+  }
+  unsigned int n_dof = prob.GetKin()->getJointNames().size();
+
+  // If target or tolerance is not given, set all to 0
+  if (targs.empty())
+    targs = DblVec(n_dof, 0);
+  if (upper_tols.empty())
+    upper_tols = DblVec(n_dof, 0);
+  if (lower_tols.empty())
+    lower_tols = DblVec(n_dof, 0);
+
+  // Adjust final timesteps if calculating near the end of a trajectory
+  if ((prob.GetNumSteps() - 3) <= first_step)
+    first_step = prob.GetNumSteps() - 3;
+  if ((prob.GetNumSteps() - 1) <= last_step)
+    last_step = prob.GetNumSteps() - 1;
+  // If only one time step is desired, calculate velocity with next step (3 steps are needed for 1 accel calculation)
+  if (last_step == first_step)
+    last_step += 2;
+  if (last_step < first_step)
+  {
+    int tmp = first_step;
+    first_step = last_step;
+    last_step = tmp;
+    ROS_WARN("Last time step for JointAccTerm comes before first step. Reversing them.");
+  }
+
+  // Check if parameters are the correct size.
+  checkParameterSize(coeffs, n_dof, "JointAccTermInfo coeffs", true);
+  checkParameterSize(targs, n_dof, "JointAccTermInfo upper_tols", true);
+  checkParameterSize(upper_tols, n_dof, "JointAccTermInfo upper_tols", true);
+  checkParameterSize(lower_tols, n_dof, "JointAccTermInfo lower_tols", true);
+
+  // Check if tolerances are all zeros
+  bool is_upper_zeros =
+      std::all_of(upper_tols.begin(), upper_tols.end(), [](double i) { return util::doubleEquals(i, 0.); });
+  bool is_lower_zeros =
+      std::all_of(lower_tols.begin(), lower_tols.end(), [](double i) { return util::doubleEquals(i, 0.); });
+
   if (term_type == TT_COST)
   {
-    prob.addCost(sco::CostPtr(new JointAccCost(prob.GetVars(), util::toVectorXd(coeffs))));
-    prob.getCosts().back()->setName(name);
+    // If the tolerances are 0, an equality cost is set. Otherwise it's a hinged "inequality" cost
+    if (is_upper_zeros && is_lower_zeros)
+    {
+      prob.addCost(sco::CostPtr(new JointAccEqCost(
+          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targs), first_step, last_step)));
+      prob.getCosts().back()->setName(name);
+    }
+    else
+    {
+      prob.addCost(sco::CostPtr(new JointAccIneqCost(prob.GetVars(),
+                                                     util::toVectorXd(coeffs),
+                                                     util::toVectorXd(targs),
+                                                     util::toVectorXd(upper_tols),
+                                                     util::toVectorXd(lower_tols),
+                                                     first_step,
+                                                     last_step)));
+      prob.getCosts().back()->setName(name);
+    }
   }
   else if (term_type == TT_CNT)
   {
-    // Calculate acceleration as ((i+1) - 2i + (i-1))/dt where dt=1
-    for (int i = first_step - 1; i <= last_step - 1; ++i)
+    // If the tolerances are 0, an equality cnt is set. Otherwise it's an inequality constraint
+    if (is_upper_zeros && is_lower_zeros)
     {
-      for (std::size_t j = 0; j < coeffs.size(); ++j)
-      {
-        sco::AffExpr acc = prob.GetVar(i + 1, j) - 2 * prob.GetVar(i, j) + prob.GetVar(i - 1, j);
-        prob.addLinearConstraint(acc - coeffs[j], sco::INEQ);
-        prob.addLinearConstraint(-acc - coeffs[j], sco::INEQ);
-      }
+      prob.addConstraint(sco::ConstraintPtr(new JointAccEqConstraint(
+          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targs), first_step, last_step)));
+      prob.getConstraints().back()->setName(name);
     }
-  }
-  else
-  {
-    ROS_WARN("JointAccTermInfo does not have a term_type defined. No cost/constraint applied");
+    else
+    {
+      prob.addConstraint(sco::ConstraintPtr(new JointAccIneqConstraint(prob.GetVars(),
+                                                                       util::toVectorXd(coeffs),
+                                                                       util::toVectorXd(targs),
+                                                                       util::toVectorXd(upper_tols),
+                                                                       util::toVectorXd(lower_tols),
+                                                                       first_step,
+                                                                       last_step)));
+      prob.getConstraints().back()->setName(name);
+    }
   }
 }
 
@@ -749,43 +838,105 @@ void JointJerkTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value
   FAIL_IF_FALSE(v.isMember("params"));
   const Json::Value& params = v["params"];
 
+  unsigned int n_dof = pci.kin->numJoints();
   json_marshal::childFromJson(params, coeffs, "coeffs");
-  unsigned n_dof = pci.kin->numJoints();
-  if (coeffs.size() == 1)
-    coeffs = DblVec(n_dof, coeffs[0]);
-  else if (coeffs.size() != n_dof)
-  {
-    PRINT_AND_THROW(boost::format("wrong number of coeffs. expected %i got %i") % n_dof % coeffs.size());
-  }
 
-  const char* all_fields[] = { "coeffs" };
+  // Optional Parameters
+  json_marshal::childFromJson(params, targs, "targs", DblVec(n_dof, 0));
+  json_marshal::childFromJson(params, upper_tols, "upper_tols", DblVec(n_dof, 0));
+  json_marshal::childFromJson(params, lower_tols, "lower_tols", DblVec(n_dof, 0));
+  json_marshal::childFromJson(params, first_step, "first_step", 0);
+  json_marshal::childFromJson(params, last_step, "last_step", pci.basic_info.n_steps - 1);
+
+  const char* all_fields[] = { "coeffs", "first_step", "last_step", "targs", "lower_tols", "upper_tols" };
   ensure_only_members(params, all_fields, sizeof(all_fields) / sizeof(char*));
 }
 
 void JointJerkTermInfo::hatch(TrajOptProb& prob)
 {
+  if ((term_type != TT_COST) && (term_type != TT_CNT))
+  {
+    ROS_WARN("JointJerkTermInfo does not have a term_type defined. No cost/constraint applied");
+  }
+  unsigned int n_dof = prob.GetKin()->getJointNames().size();
+
+  // If target or tolerance is not given, set all to 0
+  if (targs.empty())
+    targs = DblVec(n_dof, 0);
+  if (upper_tols.empty())
+    upper_tols = DblVec(n_dof, 0);
+  if (lower_tols.empty())
+    lower_tols = DblVec(n_dof, 0);
+
+  // Adjust final timesteps if calculating near the end of a trajectory
+  if ((prob.GetNumSteps() - 4) <= first_step)
+    first_step = prob.GetNumSteps() - 4;
+  if ((prob.GetNumSteps() - 1) <= last_step)
+    last_step = prob.GetNumSteps() - 1;
+  // If only one time step is desired, calculate velocity with next step (5 steps are needed for 1 jerk calculation)
+  if (last_step == first_step)
+    last_step += 4;
+  if (last_step < first_step)
+  {
+    int tmp = first_step;
+    first_step = last_step;
+    last_step = tmp;
+    ROS_WARN("Last time step for JointJerkTerm comes before first step. Reversing them.");
+  }
+
+  // Check if parameters are the correct size.
+  checkParameterSize(coeffs, n_dof, "JointJerkTermInfo coeffs", true);
+  checkParameterSize(targs, n_dof, "JointJerkTermInfo upper_tols", true);
+  checkParameterSize(upper_tols, n_dof, "JointJerkTermInfo upper_tols", true);
+  checkParameterSize(lower_tols, n_dof, "JointJerkTermInfo lower_tols", true);
+
+  // Check if tolerances are all zeros
+  bool is_upper_zeros =
+      std::all_of(upper_tols.begin(), upper_tols.end(), [](double i) { return util::doubleEquals(i, 0.); });
+  bool is_lower_zeros =
+      std::all_of(lower_tols.begin(), lower_tols.end(), [](double i) { return util::doubleEquals(i, 0.); });
+
   if (term_type == TT_COST)
   {
-    prob.addCost(sco::CostPtr(new JointJerkCost(prob.GetVars(), util::toVectorXd(coeffs))));
-    prob.getCosts().back()->setName(name);
+    // If the tolerances are 0, an equality cost is set. Otherwise it's a hinged "inequality" cost
+    if (is_upper_zeros && is_lower_zeros)
+    {
+      prob.addCost(sco::CostPtr(new JointJerkEqCost(
+          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targs), first_step, last_step)));
+      prob.getCosts().back()->setName(name);
+    }
+    else
+    {
+      prob.addCost(sco::CostPtr(new JointJerkIneqCost(prob.GetVars(),
+                                                      util::toVectorXd(coeffs),
+                                                      util::toVectorXd(targs),
+                                                      util::toVectorXd(upper_tols),
+                                                      util::toVectorXd(lower_tols),
+                                                      first_step,
+                                                      last_step)));
+      prob.getCosts().back()->setName(name);
+    }
   }
   else if (term_type == TT_CNT)
   {
-    // Calculate jerk as ((i+2) - 3(i+1) + 3(i) -(i-1))/dt where dt=1
-    for (int i = first_step - 1; i <= last_step - 1; ++i)
+    // If the tolerances are 0, an equality cnt is set. Otherwise it's an inequality constraint
+    if (is_upper_zeros && is_lower_zeros)
     {
-      for (std::size_t j = 0; j < coeffs.size(); ++j)
-      {
-        sco::AffExpr jerk =
-            prob.GetVar(i + 2, j) - 3 * prob.GetVar(i + 1, j) + 3 * prob.GetVar(i, j) - prob.GetVar(i - 1, j);
-        prob.addLinearConstraint(jerk - coeffs[j], sco::INEQ);
-        prob.addLinearConstraint(-jerk - coeffs[j], sco::INEQ);
-      }
+      prob.addConstraint(sco::ConstraintPtr(new JointJerkEqConstraint(
+          prob.GetVars(), util::toVectorXd(coeffs), util::toVectorXd(targs), first_step, last_step)));
+      prob.getConstraints().back()->setName(name);
     }
-  }
-  else
-  {
-    ROS_WARN("JointJerkTermInfo does not have a term_type defined. No cost/constraint applied");
+    else
+    {
+      prob.addConstraint(sco::ConstraintPtr(new JointJerkIneqConstraint(prob.GetVars(),
+                                                                        util::toVectorXd(coeffs),
+                                                                        util::toVectorXd(targs),
+                                                                        util::toVectorXd(upper_tols),
+                                                                        util::toVectorXd(lower_tols),
+                                                                        first_step,
+                                                                        last_step)));
+      prob.getConstraints().back()->setName(name);
+    }
   }
 }
 
@@ -902,7 +1053,8 @@ void CollisionTermInfo::hatch(TrajOptProb& prob)
     {
       for (int i = first_step; i <= last_step; ++i)
       {
-        prob.addCost(sco::CostPtr(new CollisionCost(prob.GetKin(), prob.GetEnv(), info[i - first_step], prob.GetVarRow(i))));
+        prob.addCost(
+            sco::CostPtr(new CollisionCost(prob.GetKin(), prob.GetEnv(), info[i - first_step], prob.GetVarRow(i))));
         prob.getCosts().back()->setName((boost::format("%s_%i") % name % i).str());
       }
     }

--- a/trajopt/src/trajectory_costs.cpp
+++ b/trajopt/src/trajectory_costs.cpp
@@ -48,7 +48,7 @@ JointVelEqCost::JointVelEqCost(const VarArray& vars,
                                const Eigen::VectorXd& targs,
                                int& first_step,
                                int& last_step)
-  : Cost("JointVel"), vars_(vars), coeffs_(coeffs), targs_(targs), first_step_(first_step), last_step_(last_step)
+  : Cost("JointVelEq"), vars_(vars), coeffs_(coeffs), targs_(targs), first_step_(first_step), last_step_(last_step)
 {
   for (int i = first_step_; i <= last_step_ - 1; ++i)
   {
@@ -88,7 +88,7 @@ JointVelIneqCost::JointVelIneqCost(const VarArray& vars,
                                    const Eigen::VectorXd& lower_tols,
                                    int& first_step,
                                    int& last_step)
-  : Cost("JointVel")
+  : Cost("JointVelIneq")
   , vars_(vars)
   , coeffs_(coeffs)
   , upper_tols_(upper_tols)
@@ -111,8 +111,8 @@ JointVelIneqCost::JointVelIneqCost(const VarArray& vars,
       sco::exprDec(vel, targs_[j]);        // offset to center about 0
       sco::exprInc(expr, upper_tols_[j]);  // expr_ = upper_tol
       sco::exprDec(expr, vel);             // expr = upper_tol_- (vel - targs_)
-      expr = sco::exprMult(expr, -1);             // expr = - (upper_tol_- (vel - targs_))
-      expr = sco::exprMult(expr, coeffs[j]);      // expr = - (upper_tol_- (vel - targs_)) * coeffs_
+      sco::exprScale(expr, -1);            // expr = - (upper_tol_- (vel - targs_))
+      sco::exprScale(expr, coeffs[j]);     // expr = - (upper_tol_- (vel - targs_)) * coeffs_
       expr_vec_.push_back(expr);
     }
   }
@@ -128,10 +128,10 @@ JointVelIneqCost::JointVelIneqCost(const VarArray& vars,
       sco::exprInc(vel, sco::exprMult(vars(i, j), -1));
       sco::exprInc(vel, sco::exprMult(vars(i + 1, j), 1));
 
-      sco::exprDec(vel, targs_[j]);             // offset to center about 0
-      sco::exprInc(expr_neg, lower_tols_[j]);   // expr_ = lower_tol_
-      sco::exprDec(expr_neg, vel);              // expr = lower_tol_- (vel - targs_)
-      expr_neg = sco::exprMult(expr_neg, coeffs[j]);       // expr = (lower_tol_- (vel - targs_)) * coeffs_
+      sco::exprDec(vel, targs_[j]);            // offset to center about 0
+      sco::exprInc(expr_neg, lower_tols_[j]);  // expr_ = lower_tol_
+      sco::exprDec(expr_neg, vel);             // expr = lower_tol_- (vel - targs_)
+      sco::exprScale(expr_neg, coeffs[j]);     // expr = (lower_tol_- (vel - targs_)) * coeffs_
       expr_vec_.push_back(expr_neg);
     }
   }
@@ -169,7 +169,7 @@ JointVelEqConstraint::JointVelEqConstraint(const VarArray& vars,
                                            const Eigen::VectorXd& targs,
                                            int& first_step,
                                            int& last_step)
-  : EqConstraint("JointVel")
+  : EqConstraint("JointVelEq")
   , vars_(vars)
   , coeffs_(coeffs)
   , targs_(targs)
@@ -206,7 +206,7 @@ sco::ConvexConstraintsPtr JointVelEqConstraint::convex(const DblVec& /*x*/, sco:
   sco::ConvexConstraintsPtr out(new sco::ConvexConstraints(model));
   for (sco::AffExpr expr : expr_vec_)
   {
-  out->addEqCnt(expr);
+    out->addEqCnt(expr);
   }
   return out;
 }
@@ -218,7 +218,7 @@ JointVelIneqConstraint::JointVelIneqConstraint(const VarArray& vars,
                                                const Eigen::VectorXd& lower_tols,
                                                int& first_step,
                                                int& last_step)
-  : IneqConstraint("JointVel")
+  : IneqConstraint("JointVelIneq")
   , vars_(vars)
   , coeffs_(coeffs)
   , upper_tols_(upper_tols)
@@ -238,16 +238,16 @@ JointVelIneqConstraint::JointVelIneqConstraint(const VarArray& vars,
       sco::exprInc(vel, sco::exprMult(vars(i, j), -1));
       sco::exprInc(vel, sco::exprMult(vars(i + 1, j), 1));
 
-      sco::exprDec(vel, targs_[j]);         // offset to center about 0
+      sco::exprDec(vel, targs_[j]);        // offset to center about 0
       sco::exprInc(expr, upper_tols_[j]);  // expr_ = upper_tol
       sco::exprDec(expr, vel);             // expr = upper_tol_- (vel - targs_)
-      expr = sco::exprMult(expr, -1);             // expr = - (upper_tol_- (vel - targs_))
-      expr = sco::exprMult(expr, coeffs[j]);      // expr = - (upper_tol_- (vel - targs_)) * coeffs_
+      sco::exprScale(expr, -1);            // expr = - (upper_tol_- (vel - targs_))
+      sco::exprScale(expr, coeffs[j]);     // expr = - (upper_tol_- (vel - targs_)) * coeffs_
       expr_vec_.push_back(expr);
     }
   }
 
-  // Form upper limit expr = - (upper_tol-(vel-targ))
+  // Form lower limit expr = (upper_tol-(vel-targ))
   for (int i = first_step_; i <= last_step_ - 1; ++i)
   {
     for (int j = 0; j < vars.cols(); ++j)
@@ -258,15 +258,14 @@ JointVelIneqConstraint::JointVelIneqConstraint(const VarArray& vars,
       sco::exprInc(vel, sco::exprMult(vars(i, j), -1));
       sco::exprInc(vel, sco::exprMult(vars(i + 1, j), 1));
 
-      sco::exprDec(vel, targs_[j]);             // offset to center about 0
-      sco::exprInc(expr_neg, lower_tols_[j]);   // expr_ = lower_tol_
-      sco::exprDec(expr_neg, vel);              // expr = lower_tol_- (vel - targs_)
-      expr_neg = sco::exprMult(expr_neg, coeffs[j]);       // expr = (lower_tol_- (vel - targs_)) * coeffs_
+      sco::exprDec(vel, targs_[j]);            // offset to center about 0
+      sco::exprInc(expr_neg, lower_tols_[j]);  // expr_ = lower_tol_
+      sco::exprDec(expr_neg, vel);             // expr = lower_tol_- (vel - targs_)
+      sco::exprScale(expr_neg, coeffs[j]);     // expr = (lower_tol_- (vel - targs_)) * coeffs_
       expr_vec_.push_back(expr_neg);
     }
   }
 }
-
 
 DblVec JointVelIneqConstraint::value(const DblVec& xvec)
 {
@@ -298,60 +297,572 @@ sco::ConvexConstraintsPtr JointVelIneqConstraint::convex(const DblVec& /*x*/, sc
 }
 
 //////////////////// Acceleration /////////////////////
-JointAccCost::JointAccCost(const VarArray& vars, const Eigen::VectorXd& coeffs)
-  : Cost("JointAcc"), vars_(vars), coeffs_(coeffs)
+JointAccEqCost::JointAccEqCost(const VarArray& vars,
+                               const Eigen::VectorXd& coeffs,
+                               const Eigen::VectorXd& targs,
+                               int& first_step,
+                               int& last_step)
+  : Cost("JointAccEq"), vars_(vars), coeffs_(coeffs), targs_(targs), first_step_(first_step), last_step_(last_step)
 {
-  for (int i = 0; i < vars.rows() - 2; ++i)
+  for (int i = first_step_; i <= last_step_ - 2; ++i)
   {
     for (int j = 0; j < vars.cols(); ++j)
     {
+      // acc = (x3 - 2*x2 + x1) - targ
       sco::AffExpr acc;
       sco::exprInc(acc, sco::exprMult(vars(i, j), 1.0));
       sco::exprInc(acc, sco::exprMult(vars(i + 1, j), -2.0));
       sco::exprInc(acc, sco::exprMult(vars(i + 2, j), 1.0));
+
+      sco::exprDec(acc, targs_[j]);
+      // expr_ = coeff * acc^2
       sco::exprInc(expr_, sco::exprMult(sco::exprSquare(acc), coeffs_[j]));
     }
   }
 }
-double JointAccCost::value(const DblVec& xvec)
+double JointAccEqCost::value(const DblVec& xvec)
 {
-  Eigen::MatrixXd traj = getTraj(xvec, vars_);
-  return (diffAxis0(diffAxis0(traj)).array().square().matrix() * coeffs_.asDiagonal()).sum();
+  // Convert vector from optimization to trajectory
+  Eigen::MatrixXd traj = (getTraj(xvec, vars_));
+  // Takes diff b/n the subsequent rows and subtract each row by the targs_ vector
+  Eigen::MatrixXd diff =
+      (diffAxis0(diffAxis0(traj.block(first_step_, 0, last_step_ - first_step_ + 1, traj.cols())))).rowwise() -
+      targs_.transpose();
+  // Element-wise square it, multiply it by a diagonal matrix of coefficients, and sums output
+  return (diff.array().square().matrix() * coeffs_.asDiagonal()).sum();
 }
-sco::ConvexObjectivePtr JointAccCost::convex(const DblVec& /*x*/, sco::Model* model)
+sco::ConvexObjectivePtr JointAccEqCost::convex(const DblVec& /*x*/, sco::Model* model)
 {
   sco::ConvexObjectivePtr out(new sco::ConvexObjective(model));
   out->addQuadExpr(expr_);
   return out;
 }
 
-//////////////////// Jerk /////////////////////
-JointJerkCost::JointJerkCost(const VarArray& vars, const Eigen::VectorXd& coeffs)
-  : Cost("JointJerk"), vars_(vars), coeffs_(coeffs)
+JointAccIneqCost::JointAccIneqCost(const VarArray& vars,
+                                   const Eigen::VectorXd& coeffs,
+                                   const Eigen::VectorXd& targs,
+                                   const Eigen::VectorXd& upper_tols,
+                                   const Eigen::VectorXd& lower_tols,
+                                   int& first_step,
+                                   int& last_step)
+  : Cost("JointAccIneq")
+  , vars_(vars)
+  , coeffs_(coeffs)
+  , upper_tols_(upper_tols)
+  , lower_tols_(lower_tols)
+  , targs_(targs)
+  , first_step_(first_step)
+  , last_step_(last_step)
 {
-  for (int i = 0; i < vars.rows() - 4; ++i)
+  // Form upper limit expr = - (upper_tol-(acc-targ))
+  for (int i = first_step_; i <= last_step_ - 2; ++i)
   {
     for (int j = 0; j < vars.cols(); ++j)
     {
+      sco::AffExpr expr;
+      // acc = (x3 - 2*x2 + x1) - targ
       sco::AffExpr acc;
-      sco::exprInc(acc, sco::exprMult(vars(i, j), -1.0 / 2.0));
-      sco::exprInc(acc, sco::exprMult(vars(i + 1, j), 1.0));
-      sco::exprInc(acc, sco::exprMult(vars(i + 2, j), 0.0));
-      sco::exprInc(acc, sco::exprMult(vars(i + 3, j), -1.0));
-      sco::exprInc(acc, sco::exprMult(vars(i + 4, j), 1.0 / 2.0));
-      sco::exprInc(expr_, sco::exprMult(sco::exprSquare(acc), coeffs_[j]));
+      sco::exprInc(acc, sco::exprMult(vars(i, j), 1.0));
+      sco::exprInc(acc, sco::exprMult(vars(i + 1, j), -2.0));
+      sco::exprInc(acc, sco::exprMult(vars(i + 2, j), 1.0));
+
+      sco::exprDec(acc, targs_[j]);        // offset to center about 0
+      sco::exprInc(expr, upper_tols_[j]);  // expr_ = upper_tol
+      sco::exprDec(expr, acc);             // expr = upper_tol_- (vel - targs_)
+      sco::exprScale(expr, -1);            // expr = - (upper_tol_- (vel - targs_))
+      sco::exprScale(expr, coeffs[j]);     // expr = - (upper_tol_- (vel - targs_)) * coeffs_
+      expr_vec_.push_back(expr);
+    }
+  }
+
+  // Form lower limit expr = (upper_tol-(acc-targ))
+  for (int i = first_step_; i <= last_step_ - 2; ++i)
+  {
+    for (int j = 0; j < vars.cols(); ++j)
+    {
+      sco::AffExpr expr_neg;
+      // acc = (x3 - 2*x2 + x1) - targ
+      sco::AffExpr acc;
+      sco::exprInc(acc, sco::exprMult(vars(i, j), 1.0));
+      sco::exprInc(acc, sco::exprMult(vars(i + 1, j), -2.0));
+      sco::exprInc(acc, sco::exprMult(vars(i + 2, j), 1.0));
+
+      sco::exprDec(acc, targs_[j]);            // offset to center about 0
+      sco::exprInc(expr_neg, lower_tols_[j]);  // expr_ = lower_tol_
+      sco::exprDec(expr_neg, acc);             // expr = lower_tol_- (vel - targs_)
+      sco::exprScale(expr_neg, coeffs[j]);     // expr = (lower_tol_- (vel - targs_)) * coeffs_
+      expr_vec_.push_back(expr_neg);
     }
   }
 }
-double JointJerkCost::value(const DblVec& xvec)
+
+double JointAccIneqCost::value(const DblVec& xvec)
 {
+  // Convert vector from optimization to trajectory
   Eigen::MatrixXd traj = getTraj(xvec, vars_);
-  return (diffAxis0(diffAxis0(diffAxis0(traj))).array().square().matrix() * coeffs_.asDiagonal()).sum();
+  // Takes diff b/n the subsequent rows to get velocity
+  Eigen::MatrixXd acc = diffAxis0(diffAxis0(traj.block(first_step_, 0, last_step_ - first_step_ + 1, traj.cols())));
+  // Subtract targets to center about 0 and then subtract from tolerance
+  Eigen::MatrixXd diff0 = (acc.rowwise() - targs_.transpose());
+  Eigen::MatrixXd diff1 = (diff0.rowwise() - upper_tols_.transpose()) * coeffs_.asDiagonal();
+  Eigen::MatrixXd diff2 = ((diff0 * -1).rowwise() + lower_tols_.transpose()) * coeffs_.asDiagonal();
+  // Applies hinge, multiplies it by a diagonal matrix of coefficients, sums each corresponding value, and converts to
+  // vector
+  return diff1.cwiseMax(0).sum() + diff2.cwiseMax(0).sum();
 }
-sco::ConvexObjectivePtr JointJerkCost::convex(const DblVec& /*x*/, sco::Model* model)
+
+sco::ConvexObjectivePtr JointAccIneqCost::convex(const DblVec& /*x*/, sco::Model* model)
+{
+  sco::ConvexObjectivePtr out(new sco::ConvexObjective(model));
+  // Add hinge cost. Set the coefficient to 1 here since we include it in the AffExpr already
+  // This is necessary since we want a seperate coefficient per joint
+  for (sco::AffExpr expr : expr_vec_)
+  {
+    out->addHinge(expr, 1);
+  }
+  return out;
+}
+
+JointAccEqConstraint::JointAccEqConstraint(const VarArray& vars,
+                                           const Eigen::VectorXd& coeffs,
+                                           const Eigen::VectorXd& targs,
+                                           int& first_step,
+                                           int& last_step)
+  : EqConstraint("JointAccEq")
+  , vars_(vars)
+  , coeffs_(coeffs)
+  , targs_(targs)
+  , first_step_(first_step)
+  , last_step_(last_step)
+{
+  for (int i = first_step_; i <= last_step_ - 2; ++i)
+  {
+    for (int j = 0; j < vars.cols(); ++j)
+    {
+      // acc = (x3 - 2*x2 + x1) - targ
+      sco::AffExpr acc;
+      sco::exprInc(acc, sco::exprMult(vars(i, j), 1.0));
+      sco::exprInc(acc, sco::exprMult(vars(i + 1, j), -2.0));
+      sco::exprInc(acc, sco::exprMult(vars(i + 2, j), 1.0));
+
+      sco::exprDec(acc, targs_[j]);  // offset to center about 0
+      // expr_ = coeff * vel - Not squared b/c QuadExpr cnt not yet supported (TODO)
+      expr_vec_.push_back(sco::exprMult(acc, coeffs_[j]));
+    }
+  }
+}
+
+DblVec JointAccEqConstraint::value(const DblVec& xvec)
+{
+  // Convert vector from optimization to trajectory
+  Eigen::MatrixXd traj = getTraj(xvec, vars_);
+  // Takes diff b/n the subsequent rows and subtract each row by the targs_ vector
+  Eigen::MatrixXd diff =
+      (diffAxis0(diffAxis0(traj.block(first_step_, 0, last_step_ - first_step_ + 1, traj.cols())))).rowwise() -
+      targs_.transpose();
+  // Squares it, multiplies it by a diagonal matrix of coefficients, and converts to vector
+  return util::toDblVec((diff.array().square()).matrix() * coeffs_.asDiagonal());
+}
+sco::ConvexConstraintsPtr JointAccEqConstraint::convex(const DblVec& /*x*/, sco::Model* model)
+{
+  sco::ConvexConstraintsPtr out(new sco::ConvexConstraints(model));
+  for (sco::AffExpr expr : expr_vec_)
+  {
+    out->addEqCnt(expr);
+  }
+  return out;
+}
+
+JointAccIneqConstraint::JointAccIneqConstraint(const VarArray& vars,
+                                               const Eigen::VectorXd& coeffs,
+                                               const Eigen::VectorXd& targs,
+                                               const Eigen::VectorXd& upper_tols,
+                                               const Eigen::VectorXd& lower_tols,
+                                               int& first_step,
+                                               int& last_step)
+  : IneqConstraint("JointAccIneq")
+  , vars_(vars)
+  , coeffs_(coeffs)
+  , upper_tols_(upper_tols)
+  , lower_tols_(lower_tols)
+  , targs_(targs)
+  , first_step_(first_step)
+  , last_step_(last_step)
+{
+  // Form upper limit expr = - (upper_tol-(vel-targ))
+  for (int i = first_step_; i <= last_step_ - 2; ++i)
+  {
+    for (int j = 0; j < vars.cols(); ++j)
+    {
+      sco::AffExpr expr;
+      // acc = (x3 - 2*x2 + x1) - targ
+      sco::AffExpr acc;
+      sco::exprInc(acc, sco::exprMult(vars(i, j), 1.0));
+      sco::exprInc(acc, sco::exprMult(vars(i + 1, j), -2.0));
+      sco::exprInc(acc, sco::exprMult(vars(i + 2, j), 1.0));
+
+      sco::exprDec(acc, targs_[j]);        // offset to center about 0
+      sco::exprInc(expr, upper_tols_[j]);  // expr_ = upper_tol
+      sco::exprDec(expr, acc);             // expr = upper_tol_- (vel - targs_)
+      sco::exprScale(expr, -1);            // expr = - (upper_tol_- (vel - targs_))
+      sco::exprScale(expr, coeffs[j]);     // expr = - (upper_tol_- (vel - targs_)) * coeffs_
+      expr_vec_.push_back(expr);
+    }
+  }
+
+  // Form upper limit expr = - (upper_tol-(vel-targ))
+  for (int i = first_step_; i <= last_step_ - 2; ++i)
+  {
+    for (int j = 0; j < vars.cols(); ++j)
+    {
+      sco::AffExpr expr_neg;
+      // acc = (x3 - 2*x2 + x1) - targ
+      sco::AffExpr acc;
+      sco::exprInc(acc, sco::exprMult(vars(i, j), 1.0));
+      sco::exprInc(acc, sco::exprMult(vars(i + 1, j), -2.0));
+      sco::exprInc(acc, sco::exprMult(vars(i + 2, j), 1.0));
+
+      sco::exprDec(acc, targs_[j]);            // offset to center about 0
+      sco::exprInc(expr_neg, lower_tols_[j]);  // expr_ = lower_tol_
+      sco::exprDec(expr_neg, acc);             // expr = lower_tol_- (vel - targs_)
+      sco::exprScale(expr_neg, coeffs[j]);     // expr = (lower_tol_- (vel - targs_)) * coeffs_
+      expr_vec_.push_back(expr_neg);
+    }
+  }
+}
+
+DblVec JointAccIneqConstraint::value(const DblVec& xvec)
+{
+  // Convert vector from optimization to trajectory
+  Eigen::MatrixXd traj = getTraj(xvec, vars_);
+  // Takes diff b/n the subsequent rows to get velocity
+  Eigen::MatrixXd acc = diffAxis0(diffAxis0(traj.block(first_step_, 0, last_step_ - first_step_ + 1, traj.cols())));
+  // Subtract targets to center about 0 and then subtract from tolerance
+  Eigen::MatrixXd diff0 = (acc.rowwise() - targs_.transpose());
+  Eigen::MatrixXd diff1 = (diff0.rowwise() - upper_tols_.transpose()) * coeffs_.asDiagonal();
+  Eigen::MatrixXd diff2 = ((diff0 * -1).rowwise() + lower_tols_.transpose()) * coeffs_.asDiagonal();
+  // Applies hinge, multiplies it by a diagonal matrix of coefficients, sums each corresponding value, and converts to
+  // vector
+  Eigen::MatrixXd out(diff1.rows(), diff1.cols() + diff2.cols());
+  out << diff1, diff2;
+  return util::toDblVec(out);
+}
+
+sco::ConvexConstraintsPtr JointAccIneqConstraint::convex(const DblVec& /*x*/, sco::Model* model)
+{
+  sco::ConvexConstraintsPtr out(new sco::ConvexConstraints(model));
+  // Add hinge cost. Set the coefficient to 1 here since we include it in the AffExpr already
+  // This is necessary since we want a seperate coefficient per joint
+  for (sco::AffExpr expr : expr_vec_)
+  {
+    out->addIneqCnt(expr);
+  }
+  return out;
+}
+
+//////////////////// Jerk /////////////////////
+// JointJerkCost::JointJerkCost(const VarArray& vars, const Eigen::VectorXd& coeffs)
+//  : Cost("JointJerk"), vars_(vars), coeffs_(coeffs)
+//{
+//  for (int i = 0; i < vars.rows() - 4; ++i)
+//  {
+//    for (int j = 0; j < vars.cols(); ++j)
+//    {
+//      sco::AffExpr acc;
+//      sco::exprInc(acc, sco::exprMult(vars(i, j), -1.0 / 2.0));
+//      sco::exprInc(acc, sco::exprMult(vars(i + 1, j), 1.0));
+//      sco::exprInc(acc, sco::exprMult(vars(i + 2, j), 0.0));
+//      sco::exprInc(acc, sco::exprMult(vars(i + 3, j), -1.0));
+//      sco::exprInc(acc, sco::exprMult(vars(i + 4, j), 1.0 / 2.0));
+//      sco::exprInc(expr_, sco::exprMult(sco::exprSquare(acc), coeffs_[j]));
+//    }
+//  }
+//}
+// double JointJerkCost::value(const DblVec& xvec)
+//{
+//  Eigen::MatrixXd traj = getTraj(xvec, vars_);
+//  return (diffAxis0(diffAxis0(diffAxis0(traj))).array().square().matrix() * coeffs_.asDiagonal()).sum();
+//}
+// sco::ConvexObjectivePtr JointJerkCost::convex(const DblVec& /*x*/, sco::Model* model)
+//{
+//  sco::ConvexObjectivePtr out(new sco::ConvexObjective(model));
+//  out->addQuadExpr(expr_);
+//  return out;
+//}
+JointJerkEqCost::JointJerkEqCost(const VarArray& vars,
+                                 const Eigen::VectorXd& coeffs,
+                                 const Eigen::VectorXd& targs,
+                                 int& first_step,
+                                 int& last_step)
+  : Cost("JointJerkEq"), vars_(vars), coeffs_(coeffs), targs_(targs), first_step_(first_step), last_step_(last_step)
+{
+  for (int i = first_step_; i <= last_step_ - 4; ++i)
+  {
+    for (int j = 0; j < vars.cols(); ++j)
+    {
+      sco::AffExpr jerk;
+      sco::exprInc(jerk, sco::exprMult(vars(i, j), -1.0 / 2.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 1, j), 1.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 2, j), 0.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 3, j), -1.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 4, j), 1.0 / 2.0));
+
+      sco::exprDec(jerk, targs_[j]);
+      // expr_ = coeff * jerk^2
+      sco::exprInc(expr_, sco::exprMult(sco::exprSquare(jerk), coeffs_[j]));
+    }
+  }
+}
+double JointJerkEqCost::value(const DblVec& xvec)
+{
+  // Convert vector from optimization to trajectory
+  Eigen::MatrixXd traj = (getTraj(xvec, vars_));
+  // Takes diff b/n the subsequent rows and subtract each row by the targs_ vector
+  Eigen::MatrixXd diff =
+      (diffAxis0(diffAxis0(diffAxis0(traj.block(first_step_, 0, last_step_ - first_step_ + 1, traj.cols())))))
+          .rowwise() -
+      targs_.transpose();
+  // Element-wise square it, multiply it by a diagonal matrix of coefficients, and sums output
+  return (diff.array().square().matrix() * coeffs_.asDiagonal()).sum();
+}
+sco::ConvexObjectivePtr JointJerkEqCost::convex(const DblVec& /*x*/, sco::Model* model)
 {
   sco::ConvexObjectivePtr out(new sco::ConvexObjective(model));
   out->addQuadExpr(expr_);
   return out;
 }
+
+JointJerkIneqCost::JointJerkIneqCost(const VarArray& vars,
+                                     const Eigen::VectorXd& coeffs,
+                                     const Eigen::VectorXd& targs,
+                                     const Eigen::VectorXd& upper_tols,
+                                     const Eigen::VectorXd& lower_tols,
+                                     int& first_step,
+                                     int& last_step)
+  : Cost("JointJerkIneq")
+  , vars_(vars)
+  , coeffs_(coeffs)
+  , upper_tols_(upper_tols)
+  , lower_tols_(lower_tols)
+  , targs_(targs)
+  , first_step_(first_step)
+  , last_step_(last_step)
+{
+  // Form upper limit expr = - (upper_tol-(jerk-targ))
+  for (int i = first_step_; i <= last_step_ - 4; ++i)
+  {
+    for (int j = 0; j < vars.cols(); ++j)
+    {
+      sco::AffExpr expr;
+
+      sco::AffExpr jerk;
+      sco::exprInc(jerk, sco::exprMult(vars(i, j), -1.0 / 2.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 1, j), 1.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 2, j), 0.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 3, j), -1.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 4, j), 1.0 / 2.0));
+
+      sco::exprDec(jerk, targs_[j]);
+      sco::exprInc(expr, upper_tols_[j]);  // expr_ = upper_tol
+      sco::exprDec(expr, jerk);            // expr = upper_tol_- (vel - targs_)
+      sco::exprScale(expr, -1);            // expr = - (upper_tol_- (vel - targs_))
+      sco::exprScale(expr, coeffs[j]);     // expr = - (upper_tol_- (vel - targs_)) * coeffs_
+      expr_vec_.push_back(expr);
+    }
+  }
+
+  // Form lower limit expr = (upper_tol-(acc-targ))
+  for (int i = first_step_; i <= last_step_ - 2; ++i)
+  {
+    for (int j = 0; j < vars.cols(); ++j)
+    {
+      sco::AffExpr expr_neg;
+
+      sco::AffExpr jerk;
+      sco::exprInc(jerk, sco::exprMult(vars(i, j), -1.0 / 2.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 1, j), 1.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 2, j), 0.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 3, j), -1.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 4, j), 1.0 / 2.0));
+
+      sco::exprDec(jerk, targs_[j]);
+      sco::exprInc(expr_neg, lower_tols_[j]);  // expr_ = lower_tol_
+      sco::exprDec(expr_neg, jerk);            // expr = lower_tol_- (vel - targs_)
+      sco::exprScale(expr_neg, coeffs[j]);     // expr = (lower_tol_- (vel - targs_)) * coeffs_
+      expr_vec_.push_back(expr_neg);
+    }
+  }
+}
+
+double JointJerkIneqCost::value(const DblVec& xvec)
+{
+  // Convert vector from optimization to trajectory
+  Eigen::MatrixXd traj = getTraj(xvec, vars_);
+  // Takes diff b/n the subsequent rows to get velocity
+  Eigen::MatrixXd jerk =
+      diffAxis0(diffAxis0(diffAxis0(traj.block(first_step_, 0, last_step_ - first_step_ + 1, traj.cols()))));
+  // Subtract targets to center about 0 and then subtract from tolerance
+  Eigen::MatrixXd diff0 = (jerk.rowwise() - targs_.transpose());
+  Eigen::MatrixXd diff1 = (diff0.rowwise() - upper_tols_.transpose()) * coeffs_.asDiagonal();
+  Eigen::MatrixXd diff2 = ((diff0 * -1).rowwise() + lower_tols_.transpose()) * coeffs_.asDiagonal();
+  // Applies hinge, multiplies it by a diagonal matrix of coefficients, sums each corresponding value, and converts to
+  // vector
+  return diff1.cwiseMax(0).sum() + diff2.cwiseMax(0).sum();
+}
+
+sco::ConvexObjectivePtr JointJerkIneqCost::convex(const DblVec& /*x*/, sco::Model* model)
+{
+  sco::ConvexObjectivePtr out(new sco::ConvexObjective(model));
+  // Add hinge cost. Set the coefficient to 1 here since we include it in the AffExpr already
+  // This is necessary since we want a seperate coefficient per joint
+  for (sco::AffExpr expr : expr_vec_)
+  {
+    out->addHinge(expr, 1);
+  }
+  return out;
+}
+
+JointJerkEqConstraint::JointJerkEqConstraint(const VarArray& vars,
+                                             const Eigen::VectorXd& coeffs,
+                                             const Eigen::VectorXd& targs,
+                                             int& first_step,
+                                             int& last_step)
+  : EqConstraint("JointJerkEq")
+  , vars_(vars)
+  , coeffs_(coeffs)
+  , targs_(targs)
+  , first_step_(first_step)
+  , last_step_(last_step)
+{
+  for (int i = first_step_; i <= last_step_ - 2; ++i)
+  {
+    for (int j = 0; j < vars.cols(); ++j)
+    {
+      sco::AffExpr jerk;
+      sco::exprInc(jerk, sco::exprMult(vars(i, j), -1.0 / 2.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 1, j), 1.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 2, j), 0.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 3, j), -1.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 4, j), 1.0 / 2.0));
+
+      sco::exprDec(jerk, targs_[j]);  // offset to center about 0
+      // expr_ = coeff * vel - Not squared b/c QuadExpr cnt not yet supported (TODO)
+      expr_vec_.push_back(sco::exprMult(jerk, coeffs_[j]));
+    }
+  }
+}
+
+DblVec JointJerkEqConstraint::value(const DblVec& xvec)
+{
+  // Convert vector from optimization to trajectory
+  Eigen::MatrixXd traj = getTraj(xvec, vars_);
+  // Takes diff b/n the subsequent rows and subtract each row by the targs_ vector
+  Eigen::MatrixXd diff =
+      (diffAxis0(diffAxis0(diffAxis0(traj.block(first_step_, 0, last_step_ - first_step_ + 1, traj.cols())))))
+          .rowwise() -
+      targs_.transpose();
+  // Squares it, multiplies it by a diagonal matrix of coefficients, and converts to vector
+  return util::toDblVec((diff.array().square()).matrix() * coeffs_.asDiagonal());
+}
+sco::ConvexConstraintsPtr JointJerkEqConstraint::convex(const DblVec& /*x*/, sco::Model* model)
+{
+  sco::ConvexConstraintsPtr out(new sco::ConvexConstraints(model));
+  for (sco::AffExpr expr : expr_vec_)
+  {
+    out->addEqCnt(expr);
+  }
+  return out;
+}
+
+JointJerkIneqConstraint::JointJerkIneqConstraint(const VarArray& vars,
+                                                 const Eigen::VectorXd& coeffs,
+                                                 const Eigen::VectorXd& targs,
+                                                 const Eigen::VectorXd& upper_tols,
+                                                 const Eigen::VectorXd& lower_tols,
+                                                 int& first_step,
+                                                 int& last_step)
+  : IneqConstraint("JointJerkIneq")
+  , vars_(vars)
+  , coeffs_(coeffs)
+  , upper_tols_(upper_tols)
+  , lower_tols_(lower_tols)
+  , targs_(targs)
+  , first_step_(first_step)
+  , last_step_(last_step)
+{
+  // Form upper limit expr = - (upper_tol-(vel-targ))
+  for (int i = first_step_; i <= last_step_ - 2; ++i)
+  {
+    for (int j = 0; j < vars.cols(); ++j)
+    {
+      sco::AffExpr expr;
+
+      sco::AffExpr jerk;
+      sco::exprInc(jerk, sco::exprMult(vars(i, j), -1.0 / 2.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 1, j), 1.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 2, j), 0.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 3, j), -1.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 4, j), 1.0 / 2.0));
+
+      sco::exprDec(jerk, targs_[j]);       // offset to center about 0
+      sco::exprInc(expr, upper_tols_[j]);  // expr_ = upper_tol
+      sco::exprDec(expr, jerk);            // expr = upper_tol_- (vel - targs_)
+      sco::exprScale(expr, -1);            // expr = - (upper_tol_- (vel - targs_))
+      sco::exprScale(expr, coeffs[j]);     // expr = - (upper_tol_- (vel - targs_)) * coeffs_
+      expr_vec_.push_back(expr);
+    }
+  }
+
+  // Form upper limit expr = - (upper_tol-(vel-targ))
+  for (int i = first_step_; i <= last_step_ - 1; ++i)
+  {
+    for (int j = 0; j < vars.cols(); ++j)
+    {
+      sco::AffExpr expr_neg;
+
+      sco::AffExpr jerk;
+      sco::exprInc(jerk, sco::exprMult(vars(i, j), -1.0 / 2.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 1, j), 1.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 2, j), 0.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 3, j), -1.0));
+      sco::exprInc(jerk, sco::exprMult(vars(i + 4, j), 1.0 / 2.0));
+
+      sco::exprDec(jerk, targs_[j]);           // offset to center about 0
+      sco::exprInc(expr_neg, lower_tols_[j]);  // expr_ = lower_tol_
+      sco::exprDec(expr_neg, jerk);            // expr = lower_tol_- (vel - targs_)
+      sco::exprScale(expr_neg, coeffs[j]);     // expr = (lower_tol_- (vel - targs_)) * coeffs_
+      expr_vec_.push_back(expr_neg);
+    }
+  }
+}
+
+DblVec JointJerkIneqConstraint::value(const DblVec& xvec)
+{
+  // Convert vector from optimization to trajectory
+  Eigen::MatrixXd traj = getTraj(xvec, vars_);
+  // Takes diff b/n the subsequent rows to get velocity
+  Eigen::MatrixXd acc = diffAxis0(diffAxis0(traj.block(first_step_, 0, last_step_ - first_step_ + 1, traj.cols())));
+  // Subtract targets to center about 0 and then subtract from tolerance
+  Eigen::MatrixXd diff0 = (acc.rowwise() - targs_.transpose());
+  Eigen::MatrixXd diff1 = (diff0.rowwise() - upper_tols_.transpose()) * coeffs_.asDiagonal();
+  Eigen::MatrixXd diff2 = ((diff0 * -1).rowwise() + lower_tols_.transpose()) * coeffs_.asDiagonal();
+  // Applies hinge, multiplies it by a diagonal matrix of coefficients, sums each corresponding value, and converts to
+  // vector
+  Eigen::MatrixXd out(diff1.rows(), diff1.cols() + diff2.cols());
+  out << diff1, diff2;
+  return util::toDblVec(out);
+}
+
+sco::ConvexConstraintsPtr JointJerkIneqConstraint::convex(const DblVec& /*x*/, sco::Model* model)
+{
+  sco::ConvexConstraintsPtr out(new sco::ConvexConstraints(model));
+  // Add hinge cost. Set the coefficient to 1 here since we include it in the AffExpr already
+  // This is necessary since we want a seperate coefficient per joint
+  for (sco::AffExpr expr : expr_vec_)
+  {
+    out->addIneqCnt(expr);
+  }
+  return out;
+}
+
 }  // namespace trajopt

--- a/trajopt/src/trajectory_costs.cpp
+++ b/trajopt/src/trajectory_costs.cpp
@@ -2,6 +2,7 @@
 #include <trajopt/trajectory_costs.hpp>
 #include <trajopt_sco/expr_ops.hpp>
 #include <trajopt_sco/modeling_utils.hpp>
+#include <trajopt_utils/eigen_conversions.hpp>
 
 namespace
 {
@@ -14,9 +15,10 @@ static Eigen::MatrixXd diffAxis0(const Eigen::MatrixXd& in)
 
 namespace trajopt
 {
-//////////// Quadratic cost functions /////////////////
+//////////// Joint cost functions /////////////////
 
-JointPosCost::JointPosCost(const sco::VarVector& vars, const Eigen::VectorXd& vals, const Eigen::VectorXd& coeffs)
+ //////////////////// Position /////////////////////
+ JointPosCost::JointPosCost(const VarVector& vars, const VectorXd& vals, const VectorXd& coeffs)
   : Cost("JointPos"), vars_(vars), vals_(vals), coeffs_(coeffs)
 {
   for (std::size_t i = 0; i < vars.size(); ++i)
@@ -40,6 +42,7 @@ sco::ConvexObjectivePtr JointPosCost::convex(const DblVec& /*x*/, sco::Model* mo
   return out;
 }
 
+ //////////////////// Velocity /////////////////////
 JointVelEqCost::JointVelEqCost(const VarArray& vars, const VectorXd& coeffs, const VectorXd& targs)
   : Cost("JointVel"), vars_(vars), coeffs_(coeffs), targs_(targs)
 {
@@ -143,6 +146,113 @@ ConvexObjectivePtr JointVelIneqCost::convex(const vector<double>& /*x*/, Model* 
   return out;
 }
 
+
+
+JointVelEqConstraint::JointVelEqConstraint(const VarArray& vars, const VectorXd& coeffs, const VectorXd& targs)
+  : EqConstraint("JointVel"), vars_(vars), coeffs_(coeffs), targs_(targs)
+{
+  for (int i = 0; i < vars.rows() - 1; ++i)
+  {
+    for (int j = 0; j < vars.cols(); ++j)
+    {
+      // vel = (x2 - x1) - targ
+      AffExpr vel;
+      exprInc(vel, exprMult(vars(i, j), -1));
+      exprInc(vel, exprMult(vars(i + 1, j), 1));
+      exprDec(vel, targs_[j]);
+      // expr_ = coeff * vel^2
+      exprInc(expr_, exprMult(vel, coeffs_[j]));
+    }
+  }
+}
+vector<double> JointVelEqConstraint::value(const vector<double>& xvec)
+{
+  // Convert vector from optimization to trajectory
+  MatrixXd traj = getTraj(xvec, vars_);
+  // Takes diff b/n the subsequent rows and subtract each row by the targs_ vector
+  ArrayXd diff = diffAxis0(traj).array().rowwise() - targs_.transpose().array();
+  // Squares it, multiplies it by a diagonal matrix of coefficients, and converts to vector
+  return toDblVec((diff.square().matrix() * coeffs_.asDiagonal()).matrix());
+}
+ConvexConstraintsPtr JointVelEqConstraint::convex(const vector<double>& /*x*/, Model* model)
+{
+  ConvexConstraintsPtr out(new ConvexConstraints(model));
+  out->addEqCnt(expr_);
+
+  return out;
+}
+
+JointVelIneqConstraint::JointVelIneqConstraint(const VarArray& vars,
+                                   const VectorXd& coeffs,
+                                   const VectorXd& targs,
+                                   const VectorXd& upper_tols,
+                                   const VectorXd& lower_tols)
+  : IneqConstraint("JointVel"), vars_(vars), coeffs_(coeffs), targs_(targs), upper_tols_(upper_tols), lower_tols_(lower_tols)
+{
+  // Form upper limit expr = - (upper_tol-(vel-targ))
+  for (int i = 0; i < vars.rows() - 1; ++i)
+  {
+    for (int j = 0; j < vars.cols(); ++j)
+    {
+      // vel = (x2 - x1) - targ
+      AffExpr vel;
+      exprInc(vel, exprMult(vars(i, j), -1));
+      exprInc(vel, exprMult(vars(i + 1, j), 1));
+
+      exprDec(vel, targs_[j]);        // offset to center about 0
+      exprInc(expr_, upper_tols_[j]);  // expr_ = upper_tol
+      exprDec(expr_, vel);           // expr = upper_tol_- (vel - targs_)
+      exprMult(expr_, -1);            // expr = - (upper_tol_- (vel - targs_))
+      exprMult(expr_, coeffs[j]);     // expr = - (upper_tol_- (vel - targs_)) * coeffs_
+    }
+  }
+
+  // Form upper limit expr = - (upper_tol-(vel-targ))
+  for (int i = 0; i < vars.rows() - 1; ++i)
+  {
+    for (int j = 0; j < vars.cols(); ++j)
+    {
+      // vel = (x2 - x1) - targ
+      AffExpr vel;
+      exprInc(vel, exprMult(vars(i, j), -1));
+      exprInc(vel, exprMult(vars(i + 1, j), 1));
+
+      exprDec(vel, targs_[j]);            // offset to center about 0
+      exprInc(expr_neg_, lower_tols_[j]);  // expr_ = lower_tol_
+      exprDec(expr_neg_, vel);           // expr = lower_tol_- (vel - targs_)
+      exprMult(expr_neg_, coeffs[j]);     // expr = (lower_tol_- (vel - targs_)) * coeffs_
+    }
+  }
+}
+
+vector<double> JointVelIneqConstraint::value(const vector<double>& xvec)
+{
+  // Convert vector from optimization to trajectory
+  MatrixXd traj = getTraj(xvec, vars_);
+  // Takes diff b/n the subsequent rows to get velocity
+  VectorXd vel = diffAxis0(traj);
+  // Subtract targets to center about 0 and then subtract from tolerance
+  ArrayXd diff1 = -1 * upper_tols_.transpose().array() - (vel.array().rowwise() - targs_.transpose().array());
+  ArrayXd diff2 = lower_tols_.transpose().array() - (vel.array().rowwise() - targs_.transpose().array());
+  // Applies hinge, multiplies it by a diagonal matrix of coefficients, sums each corresponding value, and converts to vector
+//  auto diff3 = (diff1.matrix().cwiseMax(0) * coeffs_.asDiagonal()) + (diff2.matrix().cwiseMax(0) * coeffs_.asDiagonal());  // Should be and ArrayXd
+  return toDblVec(((diff1.matrix().cwiseMax(0) * coeffs_.asDiagonal()) + (diff2.matrix().cwiseMax(0) * coeffs_.asDiagonal())).matrix());
+  //TODO: Constraints need to return a vector of doubles. One for each joint/timestep. If one joint is really big and one really small, we don't want them to cancel and not trigger cnt
+}
+
+ConvexConstraintsPtr JointVelIneqConstraint::convex(const vector<double>& /*x*/, Model* model)
+{
+  ConvexConstraintsPtr out(new ConvexConstraints(model));
+  // Add hinge cost. Set the coefficient to 1 here since we include it in the AffExpr already
+  // This is necessary since we want a seperate coefficient per joint
+  out->addIneqCnt(expr_);
+  out->addIneqCnt(expr_neg_);
+  return out;
+}
+
+
+
+//////////////////// Acceleration /////////////////////
 JointAccCost::JointAccCost(const VarArray& vars, const VectorXd& coeffs)
   : Cost("JointAcc"), vars_(vars), coeffs_(coeffs)
 {
@@ -170,7 +280,8 @@ sco::ConvexObjectivePtr JointAccCost::convex(const DblVec& /*x*/, sco::Model* mo
   return out;
 }
 
-JointJerkCost::JointJerkCost(const VarArray& vars, const Eigen::VectorXd& coeffs)
+ //////////////////// Jerk /////////////////////
+JointJerkCost::JointJerkCost(const VarArray& vars, const VectorXd& coeffs)
   : Cost("JointJerk"), vars_(vars), coeffs_(coeffs)
 {
   for (int i = 0; i < vars.rows() - 4; ++i)

--- a/trajopt/src/trajectory_costs.cpp
+++ b/trajopt/src/trajectory_costs.cpp
@@ -40,33 +40,110 @@ sco::ConvexObjectivePtr JointPosCost::convex(const DblVec& /*x*/, sco::Model* mo
   return out;
 }
 
-JointVelCost::JointVelCost(const VarArray& vars, const Eigen::VectorXd& coeffs)
-  : Cost("JointVel"), vars_(vars), coeffs_(coeffs)
+JointVelEqCost::JointVelEqCost(const VarArray& vars, const VectorXd& coeffs, const VectorXd& targs)
+  : Cost("JointVel"), vars_(vars), coeffs_(coeffs), targs_(targs)
 {
   for (int i = 0; i < vars.rows() - 1; ++i)
   {
     for (int j = 0; j < vars.cols(); ++j)
     {
+      // vel = (x2 - x1) - targ
       sco::AffExpr vel;
       sco::exprInc(vel, sco::exprMult(vars(i, j), -1));
       sco::exprInc(vel, sco::exprMult(vars(i + 1, j), 1));
-      sco::exprInc(expr_, sco::exprMult(sco::exprSquare(vel), coeffs_[j]));
+      exprDec(vel, targs_[j]);
+      // expr_ = coeff * vel^2
+      exprInc(expr_, exprMult(exprSquare(vel), coeffs_[j]));
     }
   }
 }
-double JointVelCost::value(const DblVec& xvec)
+double JointVelEqCost::value(const vector<double>& xvec)
 {
-  Eigen::MatrixXd traj = getTraj(xvec, vars_);
-  return (diffAxis0(traj).array().square().matrix() * coeffs_.asDiagonal()).sum();
+  // Convert vector from optimization to trajectory
+  MatrixXd traj = getTraj(xvec, vars_);
+  // Takes diff b/n the subsequent rows and subtract each row by the targs_ vector
+  ArrayXd diff = diffAxis0(traj).array().rowwise() - targs_.transpose().array();
+  // Squares it, multiplies it by a diagonal matrix of coefficients, and sums output
+  return (diff.square().matrix() * coeffs_.asDiagonal()).sum();
 }
-sco::ConvexObjectivePtr JointVelCost::convex(const DblVec& /*x*/, sco::Model* model)
+ConvexObjectivePtr JointVelEqCost::convex(const vector<double>& /*x*/, Model* model)
 {
   sco::ConvexObjectivePtr out(new sco::ConvexObjective(model));
   out->addQuadExpr(expr_);
+  //  out->addHinge();
+  //  out->addAbs();
+  // etc
   return out;
 }
 
-JointAccCost::JointAccCost(const VarArray& vars, const Eigen::VectorXd& coeffs)
+JointVelIneqCost::JointVelIneqCost(const VarArray& vars,
+                                   const VectorXd& coeffs,
+                                   const VectorXd& targs,
+                                   const VectorXd& upper_tols,
+                                   const VectorXd& lower_tols)
+  : Cost("JointVel"), vars_(vars), coeffs_(coeffs), targs_(targs), upper_tols_(upper_tols), lower_tols_(lower_tols)
+{
+  // Form upper limit expr = - (upper_tol-(vel-targ))
+  for (int i = 0; i < vars.rows() - 1; ++i)
+  {
+    for (int j = 0; j < vars.cols(); ++j)
+    {
+      // vel = (x2 - x1) - targ
+      AffExpr vel;
+      exprInc(vel, exprMult(vars(i, j), -1));
+      exprInc(vel, exprMult(vars(i + 1, j), 1));
+
+      exprDec(vel, targs_[j]);        // offset to center about 0
+      exprInc(expr_, upper_tols_[j]);  // expr_ = upper_tol
+      exprDec(expr_, vel);           // expr = upper_tol_- (vel - targs_)
+      exprMult(expr_, -1);            // expr = - (upper_tol_- (vel - targs_))
+      exprMult(expr_, coeffs[j]);     // expr = - (upper_tol_- (vel - targs_)) * coeffs_
+    }
+  }
+
+  // Form upper limit expr = - (upper_tol-(vel-targ))
+  for (int i = 0; i < vars.rows() - 1; ++i)
+  {
+    for (int j = 0; j < vars.cols(); ++j)
+    {
+      // vel = (x2 - x1) - targ
+      AffExpr vel;
+      exprInc(vel, exprMult(vars(i, j), -1));
+      exprInc(vel, exprMult(vars(i + 1, j), 1));
+
+      exprDec(vel, targs_[j]);            // offset to center about 0
+      exprInc(expr_neg_, lower_tols_[j]);  // expr_ = lower_tol_
+      exprDec(expr_neg_, vel);           // expr = lower_tol_- (vel - targs_)
+      exprMult(expr_neg_, coeffs[j]);     // expr = (lower_tol_- (vel - targs_)) * coeffs_
+    }
+  }
+}
+
+double JointVelIneqCost::value(const vector<double>& xvec)
+{
+  // Convert vector from optimization to trajectory
+  MatrixXd traj = getTraj(xvec, vars_);
+  // Takes diff b/n the subsequent rows to get velocity
+  VectorXd vel = diffAxis0(traj);
+  // Subtract targets to center about 0 and then subtract from tolerance
+  ArrayXd diff1 = -1 * upper_tols_.transpose().array() - (vel.array().rowwise() - targs_.transpose().array());
+  ArrayXd diff2 = lower_tols_.transpose().array() - (vel.array().rowwise() - targs_.transpose().array());
+  // Applies hinge, multiplies it by a diagonal matrix of coefficients, and sums outputs of the two
+  return (diff1.matrix().cwiseMax(0) * coeffs_.asDiagonal()).sum() +
+         (diff2.matrix().cwiseMax(0) * coeffs_.asDiagonal()).sum();
+}
+
+ConvexObjectivePtr JointVelIneqCost::convex(const vector<double>& /*x*/, Model* model)
+{
+  ConvexObjectivePtr out(new ConvexObjective(model));
+  // Add hinge cost. Set the coefficient to 1 here since we include it in the AffExpr already
+  // This is necessary since we want a seperate coefficient per joint
+  out->addHinge(expr_, 1);
+  out->addHinge(expr_neg_, 1);
+  return out;
+}
+
+JointAccCost::JointAccCost(const VarArray& vars, const VectorXd& coeffs)
   : Cost("JointAcc"), vars_(vars), coeffs_(coeffs)
 {
   for (int i = 0; i < vars.rows() - 2; ++i)
@@ -121,4 +198,4 @@ sco::ConvexObjectivePtr JointJerkCost::convex(const DblVec& /*x*/, sco::Model* m
   out->addQuadExpr(expr_);
   return out;
 }
-}
+}  // namespace trajopt

--- a/trajopt/src/trajectory_costs.cpp
+++ b/trajopt/src/trajectory_costs.cpp
@@ -5,11 +5,12 @@
 
 namespace
 {
+/** @brief Returns the difference between each row of a matrixXd and the row before */
 static Eigen::MatrixXd diffAxis0(const Eigen::MatrixXd& in)
 {
   return in.middleRows(1, in.rows() - 1) - in.middleRows(0, in.rows() - 1);
 }
-}
+}  // namespace
 
 namespace trajopt
 {

--- a/trajopt/test/costs_unit.cpp
+++ b/trajopt/test/costs_unit.cpp
@@ -27,7 +27,7 @@ using namespace tesseract;
 const std::string ROBOT_DESCRIPTION_PARAM = "robot_description"; /**< Default ROS parameter for robot description */
 const std::string ROBOT_SEMANTIC_PARAM = "robot_description_semantic"; /**< Default ROS parameter for robot
                                                                           description */
-bool plotting = false;                                                 /**< Enable plotting */
+static bool plotting = false;                                                 /**< Enable plotting */
 
 class CostsTest : public testing::TestWithParam<const char*>
 {
@@ -94,7 +94,7 @@ TEST_F(CostsTest, equality_jointVel)
   // Constraint that first step velocity should be zero
   std::shared_ptr<JointVelTermInfo> jv = std::shared_ptr<JointVelTermInfo>(new JointVelTermInfo);
   jv->coeffs = std::vector<double>(7, 10.0);
-  jv->targs = std::vector<double>(7.0, cnt_targ);
+  jv->targets = std::vector<double>(7.0, cnt_targ);
   jv->first_step = 0;
   jv->last_step = 0;
   jv->name = "joint_vel_single";
@@ -104,7 +104,7 @@ TEST_F(CostsTest, equality_jointVel)
   // All the rest of the joint velocities have a cost to some non zero value
   std::shared_ptr<JointVelTermInfo> jv2 = std::shared_ptr<JointVelTermInfo>(new JointVelTermInfo);
   jv2->coeffs = std::vector<double>(7, 10.0);
-  jv2->targs = std::vector<double>(7.0, cost_targ);
+  jv2->targets = std::vector<double>(7.0, cost_targ);
   jv2->first_step = 0;
   jv2->last_step = pci.basic_info.n_steps - 1;
   jv2->name = "joint_vel_all";
@@ -185,7 +185,7 @@ TEST_F(CostsTest, inequality_jointVel)
   // Constraint that limits velocity
   std::shared_ptr<JointVelTermInfo> jv = std::shared_ptr<JointVelTermInfo>(new JointVelTermInfo);
   jv->coeffs = std::vector<double>(7, 1.0);
-  jv->targs = std::vector<double>(7.0, 0);
+  jv->targets = std::vector<double>(7.0, 0);
   jv->lower_tols = std::vector<double>(7.0, lower_tol);
   jv->upper_tols = std::vector<double>(7.0, upper_tol);
   jv->first_step = 0;
@@ -197,7 +197,7 @@ TEST_F(CostsTest, inequality_jointVel)
   // Joint Velocities also have a cost to some non zero value
   std::shared_ptr<JointVelTermInfo> jv2 = std::shared_ptr<JointVelTermInfo>(new JointVelTermInfo);
   jv2->coeffs = std::vector<double>(7, 1.0);
-  jv2->targs = std::vector<double>(7.0, cost_targ1);
+  jv2->targets = std::vector<double>(7.0, cost_targ1);
   jv2->lower_tols = std::vector<double>(7.0, -0.01);
   jv2->upper_tols = std::vector<double>(7.0, 0.0);
   jv2->first_step = 0;
@@ -208,7 +208,7 @@ TEST_F(CostsTest, inequality_jointVel)
 
   std::shared_ptr<JointVelTermInfo> jv3 = std::shared_ptr<JointVelTermInfo>(new JointVelTermInfo);
   jv3->coeffs = std::vector<double>(7, 1.0);
-  jv3->targs = std::vector<double>(7.0, cost_targ2);
+  jv3->targets = std::vector<double>(7.0, cost_targ2);
   jv3->lower_tols = std::vector<double>(7.0, -0.01);
   jv3->upper_tols = std::vector<double>(7.0, 0.01);
   jv3->first_step = (pci.basic_info.n_steps - 1) / 2 + 1;
@@ -293,7 +293,7 @@ TEST_F(CostsTest, equality_jointAcc)
   // Constraint that first step velocity should be zero
   std::shared_ptr<JointAccTermInfo> jv = std::shared_ptr<JointAccTermInfo>(new JointAccTermInfo);
   jv->coeffs = std::vector<double>(7, 10.0);
-  jv->targs = std::vector<double>(7.0, cnt_targ);
+  jv->targets = std::vector<double>(7.0, cnt_targ);
   jv->first_step = 0;
   jv->last_step = 0;
   jv->name = "joint_acc_single";
@@ -303,7 +303,7 @@ TEST_F(CostsTest, equality_jointAcc)
   // All the rest of the joint velocities have a cost to some non zero value
   std::shared_ptr<JointAccTermInfo> jv2 = std::shared_ptr<JointAccTermInfo>(new JointAccTermInfo);
   jv2->coeffs = std::vector<double>(7, 10.0);
-  jv2->targs = std::vector<double>(7.0, cost_targ);
+  jv2->targets = std::vector<double>(7.0, cost_targ);
   jv2->first_step = 0;
   jv2->last_step = pci.basic_info.n_steps - 1;
   jv2->name = "joint_acc_all";
@@ -385,7 +385,7 @@ TEST_F(CostsTest, inequality_jointAcc)
   // Constraint that limits accel
   std::shared_ptr<JointAccTermInfo> jv = std::shared_ptr<JointAccTermInfo>(new JointAccTermInfo);
   jv->coeffs = std::vector<double>(7, 1.0);
-  jv->targs = std::vector<double>(7.0, 0);
+  jv->targets = std::vector<double>(7.0, 0);
   jv->lower_tols = std::vector<double>(7.0, lower_tol);
   jv->upper_tols = std::vector<double>(7.0, upper_tol);
   jv->first_step = 0;
@@ -397,7 +397,7 @@ TEST_F(CostsTest, inequality_jointAcc)
   // Joint accel also have a cost to some non zero value
   std::shared_ptr<JointAccTermInfo> jv2 = std::shared_ptr<JointAccTermInfo>(new JointAccTermInfo);
   jv2->coeffs = std::vector<double>(7, 1.0);
-  jv2->targs = std::vector<double>(7.0, cost_targ1);
+  jv2->targets = std::vector<double>(7.0, cost_targ1);
   jv2->lower_tols = std::vector<double>(7.0, -0.01);
   jv2->upper_tols = std::vector<double>(7.0, 0.01);
   jv2->first_step = 0;
@@ -408,7 +408,7 @@ TEST_F(CostsTest, inequality_jointAcc)
 
   std::shared_ptr<JointAccTermInfo> jv3 = std::shared_ptr<JointAccTermInfo>(new JointAccTermInfo);
   jv3->coeffs = std::vector<double>(7, 1.0);
-  jv3->targs = std::vector<double>(7.0, cost_targ2);
+  jv3->targets = std::vector<double>(7.0, cost_targ2);
   jv3->lower_tols = std::vector<double>(7.0, -0.01);
   jv3->upper_tols = std::vector<double>(7.0, 0.01);
   jv3->first_step = (pci.basic_info.n_steps - 1) / 2 + 1;

--- a/trajopt/test/costs_unit.cpp
+++ b/trajopt/test/costs_unit.cpp
@@ -114,7 +114,7 @@ TEST_F(CostsTest, equality_jointVel)
   TrajOptProbPtr prob = ConstructProblem(pci);
   ASSERT_TRUE(!!prob);
 
-  BasicTrustRegionSQP opt(prob);
+  sco::BasicTrustRegionSQP opt(prob);
   if (plotting)
   {
     opt.addCallback(PlotCallback(*prob, plotter_));
@@ -123,7 +123,7 @@ TEST_F(CostsTest, equality_jointVel)
   opt.initialize(trajToDblVec(prob->GetInitTraj()));
   double tStart = GetClock();
 
-  OptStatus status = opt.optimize();
+  sco::OptStatus status = opt.optimize();
 
   TrajArray output = getTraj(opt.x(), prob->GetVars());
   std::cout << "Trajectory: \n" << output << "\n";
@@ -165,7 +165,7 @@ TEST_F(CostsTest, inequality_jointVel)
   const double cost_targ2 = -0.5;
 
   const int steps = 10;
-  const double cnt_tol = 0.01;
+  const double cnt_tol = 0.0001;
 
   ProblemConstructionInfo pci(env_);
 
@@ -220,7 +220,7 @@ TEST_F(CostsTest, inequality_jointVel)
   TrajOptProbPtr prob = ConstructProblem(pci);
   ASSERT_TRUE(!!prob);
 
-  BasicTrustRegionSQP opt(prob);
+  sco::BasicTrustRegionSQP opt(prob);
   if (plotting)
   {
     opt.addCallback(PlotCallback(*prob, plotter_));
@@ -229,7 +229,7 @@ TEST_F(CostsTest, inequality_jointVel)
   opt.initialize(trajToDblVec(prob->GetInitTraj()));
   double tStart = GetClock();
 
-  OptStatus status = opt.optimize();
+  sco::OptStatus status = opt.optimize();
   ROS_DEBUG("planning time: %.3f", GetClock() - tStart);
 
   TrajArray output = getTraj(opt.x(), prob->GetVars());

--- a/trajopt/test/costs_unit.cpp
+++ b/trajopt/test/costs_unit.cpp
@@ -1,0 +1,158 @@
+#include <ctime>
+#include <gtest/gtest.h>
+#include <tesseract_ros/kdl/kdl_chain_kin.h>
+#include <tesseract_ros/kdl/kdl_env.h>
+#include <tesseract_ros/ros_basic_plotting.h>
+#include <trajopt/common.hpp>
+#include <trajopt/plot_callback.hpp>
+#include <trajopt/problem_description.hpp>
+#include <trajopt_sco/optimizers.hpp>
+#include <trajopt_test_utils.hpp>
+#include <trajopt_utils/clock.hpp>
+#include <trajopt_utils/config.hpp>
+#include <trajopt_utils/eigen_conversions.hpp>
+#include <trajopt_utils/logging.hpp>
+#include <trajopt_utils/stl_to_string.hpp>
+
+#include <ros/package.h>
+#include <ros/ros.h>
+#include <srdfdom/model.h>
+#include <urdf_parser/urdf_parser.h>
+
+using namespace trajopt;
+using namespace std;
+using namespace util;
+using namespace tesseract;
+
+const std::string ROBOT_DESCRIPTION_PARAM = "robot_description"; /**< Default ROS parameter for robot description */
+const std::string ROBOT_SEMANTIC_PARAM = "robot_description_semantic"; /**< Default ROS parameter for robot
+                                                                          description */
+bool plotting = false;                                                 /**< Enable plotting */
+
+class CostsTest : public testing::TestWithParam<const char*>
+{
+public:
+  ros::NodeHandle nh_;
+  urdf::ModelInterfaceSharedPtr urdf_model_;   /**< URDF Model */
+  srdf::ModelSharedPtr srdf_model_;            /**< SRDF Model */
+  tesseract_ros::KDLEnvPtr env_;               /**< Trajopt Basic Environment */
+  tesseract_ros::ROSBasicPlottingPtr plotter_; /**< Trajopt Plotter */
+
+  virtual void SetUp()
+  {
+    std::string urdf_xml_string, srdf_xml_string;
+    nh_.getParam(ROBOT_DESCRIPTION_PARAM, urdf_xml_string);
+    nh_.getParam(ROBOT_SEMANTIC_PARAM, srdf_xml_string);
+    urdf_model_ = urdf::parseURDF(urdf_xml_string);
+
+    srdf_model_ = srdf::ModelSharedPtr(new srdf::Model);
+    srdf_model_->initString(*urdf_model_, srdf_xml_string);
+    env_ = tesseract_ros::KDLEnvPtr(new tesseract_ros::KDLEnv);
+    assert(urdf_model_ != nullptr);
+    assert(env_ != nullptr);
+
+    bool success = env_->init(urdf_model_, srdf_model_);
+    assert(success);
+
+    gLogLevel = util::LevelError;
+  }
+};
+
+/**
+ * @brief Tests the equality jointVel cost/constraints.
+ *
+ * Sets a cost targetting the velocity of all joints at 0.1 for all timesteps.
+ * Sets a conflicting constraint on the velocity of all joints for the first timestep only.
+ * Checks to make sure that the constraint is met if the first time step and the other time steps are close to the cost
+ * target
+ */
+TEST_F(CostsTest, equality_jointVel)
+{
+  ROS_DEBUG("CostsTest, equality_jointVel");
+
+  const double cnt_targ = 0.0;
+  const double cost_targ = 0.1;
+  const int steps = 10;
+  const double cost_tol = 0.01;
+  const double cnt_tol = 0.0001;
+
+  ProblemConstructionInfo pci(env_);
+
+  // Populate Basic Info
+  pci.basic_info.n_steps = steps;
+  pci.basic_info.manip = "right_arm";
+  pci.basic_info.start_fixed = false;
+
+  // Create Kinematic Object
+  pci.kin = pci.env->getManipulator(pci.basic_info.manip);
+
+  // Populate Init Info
+  Eigen::VectorXd start_pos = pci.env->getCurrentJointValues(pci.kin->getName());
+  pci.init_info.type = InitInfo::STATIONARY;
+  pci.init_info.data = start_pos.transpose().replicate(pci.basic_info.n_steps, 1);
+
+  // Constraint that first step velocity should be zero
+  std::shared_ptr<JointVelTermInfo> jv = std::shared_ptr<JointVelTermInfo>(new JointVelTermInfo);
+  jv->coeffs = std::vector<double>(7, 10.0);
+  jv->targs = std::vector<double>(7.0, cnt_targ);
+  jv->first_step = 0;
+  jv->last_step = 0;
+  jv->name = "joint_vel_single";
+  jv->term_type = TT_CNT;
+  pci.cnt_infos.push_back(jv);
+
+  // All the rest of the joint velocities have a cost to some non zero value
+  std::shared_ptr<JointVelTermInfo> jv2 = std::shared_ptr<JointVelTermInfo>(new JointVelTermInfo);
+  jv2->coeffs = std::vector<double>(7, 10.0);
+  jv2->targs = std::vector<double>(7.0, cost_targ);
+  jv2->first_step = 0;
+  jv2->last_step = pci.basic_info.n_steps - 1;
+  jv2->name = "joint_vel_all";
+  jv2->term_type = TT_COST;
+  pci.cost_infos.push_back(jv2);
+
+  TrajOptProbPtr prob = ConstructProblem(pci);
+  ASSERT_TRUE(!!prob);
+
+  BasicTrustRegionSQP opt(prob);
+  if (plotting)
+  {
+    opt.addCallback(PlotCallback(*prob, plotter_));
+  }
+
+  opt.initialize(trajToDblVec(prob->GetInitTraj()));
+  double tStart = GetClock();
+
+  OptStatus status = opt.optimize();
+
+  TrajArray output = getTraj(opt.x(), prob->GetVars());
+  std::cout << "Trajectory: \n" << output << "\n";
+
+  // Check velocity constraint is satisfied
+  double velocity;
+  for (auto j = 0; j < output.cols(); ++j)
+  {
+    velocity = output(1, j) - output(0, j);
+    EXPECT_NEAR(velocity, cnt_targ, cnt_tol);
+  }
+  // Check velocity cost is working
+  for (auto i = 1; i < output.rows() - 1; ++i)
+  {
+    for (auto j = 0; j < output.cols(); ++j)
+    {
+      velocity = output(i + 1, j) - output(i, j);
+      EXPECT_NEAR(velocity, cost_targ, cost_tol);
+    }
+  }
+  ROS_DEBUG("planning time: %.3f", GetClock() - tStart);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "trajopt_costs_unit");
+  ros::NodeHandle pnh("~");
+
+  pnh.param("plotting", plotting, false);
+  return RUN_ALL_TESTS();
+}

--- a/trajopt/test/costs_unit.cpp
+++ b/trajopt/test/costs_unit.cpp
@@ -152,7 +152,7 @@ TEST_F(CostsTest, equality_jointVel)
  * @brief Tests inequality jointVel constraint
  *
  * Sets a cost targetting the velocity of all joints at -0.5 for the first half of the timesteps and +0.5 for the rest.
- * Sets a conflicting constraint on the velocity of all joints limiting them to +/- 0.25.
+ * Sets a conflicting constraint on the velocity of all joints limiting them to +/- 0.1.
  * Checks to make sure that the constraint is met
  */
 TEST_F(CostsTest, inequality_jointVel)
@@ -198,8 +198,8 @@ TEST_F(CostsTest, inequality_jointVel)
   std::shared_ptr<JointVelTermInfo> jv2 = std::shared_ptr<JointVelTermInfo>(new JointVelTermInfo);
   jv2->coeffs = std::vector<double>(7, 1.0);
   jv2->targs = std::vector<double>(7.0, cost_targ1);
-//  jv2->lower_tols = std::vector<double>(7.0, 0.0);
-//  jv2->upper_tols = std::vector<double>(7.0, 0.0);
+  jv2->lower_tols = std::vector<double>(7.0, -0.01);
+  jv2->upper_tols = std::vector<double>(7.0, 0.0);
   jv2->first_step = 0;
   jv2->last_step = (pci.basic_info.n_steps - 1) / 2;
   jv2->name = "joint_vel_targ_1";
@@ -209,8 +209,8 @@ TEST_F(CostsTest, inequality_jointVel)
   std::shared_ptr<JointVelTermInfo> jv3 = std::shared_ptr<JointVelTermInfo>(new JointVelTermInfo);
   jv3->coeffs = std::vector<double>(7, 1.0);
   jv3->targs = std::vector<double>(7.0, cost_targ2);
-//  jv3->lower_tols = std::vector<double>(7.0, 0.0);
-//  jv3->upper_tols = std::vector<double>(7.0, 0.0);
+  jv3->lower_tols = std::vector<double>(7.0, -0.01);
+  jv3->upper_tols = std::vector<double>(7.0, 0.01);
   jv3->first_step = (pci.basic_info.n_steps - 1) / 2 + 1;
   jv3->last_step = pci.basic_info.n_steps - 1;
   jv3->name = "joint_vel_targ_2";
@@ -235,10 +235,9 @@ TEST_F(CostsTest, inequality_jointVel)
   TrajArray output = getTraj(opt.x(), prob->GetVars());
   std::cout << "Trajectory: \n" << output << "\n";
 
-
   // Check velocity cost is working
   double velocity;
-  for (auto i = 0; i < (output.rows())/2; ++i)
+  for (auto i = 0; i < (output.rows()) / 2; ++i)
   {
     for (auto j = 0; j < output.cols(); ++j)
     {
@@ -247,7 +246,7 @@ TEST_F(CostsTest, inequality_jointVel)
       EXPECT_TRUE(velocity > lower_tol - cnt_tol);
     }
   }
-  for (auto i = (output.rows())/2+1; i < output.rows() - 1; ++i)
+  for (auto i = (output.rows()) / 2 + 1; i < output.rows() - 1; ++i)
   {
     for (auto j = 0; j < output.cols(); ++j)
     {
@@ -255,8 +254,207 @@ TEST_F(CostsTest, inequality_jointVel)
       EXPECT_TRUE(velocity < upper_tol + cnt_tol);
       EXPECT_TRUE(velocity > lower_tol - cnt_tol);
     }
+  }
+}
+
+/**
+ * @brief Tests the equality jointAcc cost/constraints.
+ *
+ * Sets a cost targetting the acceleration of all joints at 0.1 for all timesteps.
+ * Sets a conflicting constraint on the velocity of all joints for the first timestep only.
+ * Checks to make sure that the constraint is met if the first time step and the other time steps are close to the cost
+ * target
+ */
+TEST_F(CostsTest, equality_jointAcc)
+{
+  ROS_DEBUG("CostsTest, equality_jointAcc");
+
+  const double cnt_targ = 0.0;
+  const double cost_targ = 0.1;
+  const int steps = 10;
+  const double cost_tol = 0.01;
+  const double cnt_tol = 0.0001;
+
+  ProblemConstructionInfo pci(env_);
+
+  // Populate Basic Info
+  pci.basic_info.n_steps = steps;
+  pci.basic_info.manip = "right_arm";
+  pci.basic_info.start_fixed = false;
+
+  // Create Kinematic Object
+  pci.kin = pci.env->getManipulator(pci.basic_info.manip);
+
+  // Populate Init Info
+  Eigen::VectorXd start_pos = pci.env->getCurrentJointValues(pci.kin->getName());
+  pci.init_info.type = InitInfo::STATIONARY;
+  pci.init_info.data = start_pos.transpose().replicate(pci.basic_info.n_steps, 1);
+
+  // Constraint that first step velocity should be zero
+  std::shared_ptr<JointAccTermInfo> jv = std::shared_ptr<JointAccTermInfo>(new JointAccTermInfo);
+  jv->coeffs = std::vector<double>(7, 10.0);
+  jv->targs = std::vector<double>(7.0, cnt_targ);
+  jv->first_step = 0;
+  jv->last_step = 0;
+  jv->name = "joint_acc_single";
+  jv->term_type = TT_CNT;
+  pci.cnt_infos.push_back(jv);
+
+  // All the rest of the joint velocities have a cost to some non zero value
+  std::shared_ptr<JointAccTermInfo> jv2 = std::shared_ptr<JointAccTermInfo>(new JointAccTermInfo);
+  jv2->coeffs = std::vector<double>(7, 10.0);
+  jv2->targs = std::vector<double>(7.0, cost_targ);
+  jv2->first_step = 0;
+  jv2->last_step = pci.basic_info.n_steps - 1;
+  jv2->name = "joint_acc_all";
+  jv2->term_type = TT_COST;
+  pci.cost_infos.push_back(jv2);
+
+  TrajOptProbPtr prob = ConstructProblem(pci);
+  ASSERT_TRUE(!!prob);
+
+  sco::BasicTrustRegionSQP opt(prob);
+  if (plotting)
+  {
+    opt.addCallback(PlotCallback(*prob, plotter_));
   }
 
+  opt.initialize(trajToDblVec(prob->GetInitTraj()));
+  double tStart = GetClock();
+
+  sco::OptStatus status = opt.optimize();
+
+  TrajArray output = getTraj(opt.x(), prob->GetVars());
+  std::cout << "Trajectory: \n" << output << "\n";
+
+  // Check acceleration constraint is satisfied
+  double accel;
+  for (auto j = 0; j < output.cols(); ++j)
+  {
+    int i = 0;
+    accel =  output(i, j) - 2*output(i + 1, j) + output(i + 2, j);
+    EXPECT_NEAR(accel, cnt_targ, cnt_tol);
+  }
+  // Check acceleration cost is working
+  for (auto i = 1; i < output.rows() - 2; ++i)
+  {
+    for (auto j = 0; j < output.cols(); ++j)
+    {
+      accel =  output(i, j) - 2*output(i + 1, j) + output(i + 2, j);
+      EXPECT_NEAR(accel, cost_targ, cost_tol);
+    }
+  }
+  ROS_DEBUG("planning time: %.3f", GetClock() - tStart);
+}
+
+////////////////////////////////////////////////////////////////////
+/**
+ * @brief Tests inequality jointAcc constraint
+ *
+ * Sets a cost targetting the acceleration of all joints at -0.5 for the first half of the timesteps and +0.5 for the
+ * rest. Sets a conflicting constraint on the velocity of all joints limiting them to +/- 0.1. Checks to make sure that
+ * the constraint is met
+ */
+TEST_F(CostsTest, inequality_jointAcc)
+{
+  ROS_DEBUG("CostsTest, inequality_cnt_jointVel");
+
+  const double lower_tol = -0.1;
+  const double upper_tol = 0.1;
+  const double cost_targ1 = 0.5;
+  const double cost_targ2 = -0.5;
+
+  const int steps = 10;
+  const double cnt_tol = 0.0001;
+
+  ProblemConstructionInfo pci(env_);
+
+  // Populate Basic Info
+  pci.basic_info.n_steps = steps;
+  pci.basic_info.manip = "right_arm";
+  pci.basic_info.start_fixed = false;
+
+  // Create Kinematic Object
+  pci.kin = pci.env->getManipulator(pci.basic_info.manip);
+
+  // Populate Init Info
+  Eigen::VectorXd start_pos = pci.env->getCurrentJointValues(pci.kin->getName());
+  pci.init_info.type = InitInfo::STATIONARY;
+  pci.init_info.data = start_pos.transpose().replicate(pci.basic_info.n_steps, 1);
+
+  // Constraint that limits accel
+  std::shared_ptr<JointAccTermInfo> jv = std::shared_ptr<JointAccTermInfo>(new JointAccTermInfo);
+  jv->coeffs = std::vector<double>(7, 1.0);
+  jv->targs = std::vector<double>(7.0, 0);
+  jv->lower_tols = std::vector<double>(7.0, lower_tol);
+  jv->upper_tols = std::vector<double>(7.0, upper_tol);
+  jv->first_step = 0;
+  jv->last_step = pci.basic_info.n_steps - 1;
+  jv->name = "joint_acc_limits";
+  jv->term_type = TT_CNT;
+  pci.cnt_infos.push_back(jv);
+
+  // Joint accel also have a cost to some non zero value
+  std::shared_ptr<JointAccTermInfo> jv2 = std::shared_ptr<JointAccTermInfo>(new JointAccTermInfo);
+  jv2->coeffs = std::vector<double>(7, 1.0);
+  jv2->targs = std::vector<double>(7.0, cost_targ1);
+  jv2->lower_tols = std::vector<double>(7.0, -0.01);
+  jv2->upper_tols = std::vector<double>(7.0, 0.01);
+  jv2->first_step = 0;
+  jv2->last_step = (pci.basic_info.n_steps - 1) / 2;
+  jv2->name = "joint_acc_targ_1";
+  jv2->term_type = TT_COST;
+  pci.cost_infos.push_back(jv2);
+
+  std::shared_ptr<JointAccTermInfo> jv3 = std::shared_ptr<JointAccTermInfo>(new JointAccTermInfo);
+  jv3->coeffs = std::vector<double>(7, 1.0);
+  jv3->targs = std::vector<double>(7.0, cost_targ2);
+  jv3->lower_tols = std::vector<double>(7.0, -0.01);
+  jv3->upper_tols = std::vector<double>(7.0, 0.01);
+  jv3->first_step = (pci.basic_info.n_steps - 1) / 2 + 1;
+  jv3->last_step = pci.basic_info.n_steps - 1;
+  jv3->name = "joint_acc_targ_2";
+  jv3->term_type = TT_COST;
+  pci.cost_infos.push_back(jv3);
+
+  TrajOptProbPtr prob = ConstructProblem(pci);
+  ASSERT_TRUE(!!prob);
+
+  sco::BasicTrustRegionSQP opt(prob);
+  if (plotting)
+  {
+    opt.addCallback(PlotCallback(*prob, plotter_));
+  }
+
+  opt.initialize(trajToDblVec(prob->GetInitTraj()));
+  double tStart = GetClock();
+
+  sco::OptStatus status = opt.optimize();
+  ROS_DEBUG("planning time: %.3f", GetClock() - tStart);
+
+  TrajArray output = getTraj(opt.x(), prob->GetVars());
+  std::cout << "Trajectory: \n" << output << "\n";
+
+  // Check accel cost is working
+  double accel;
+  for (auto i = 0; i < (output.rows()) / 2; ++i)
+  {
+    for (auto j = 0; j < output.cols(); ++j)
+    {
+      accel =  output(i, j) - 2*output(i + 1, j) + output(i + 2, j);
+      EXPECT_TRUE(accel < upper_tol + cnt_tol);
+      EXPECT_TRUE(accel > lower_tol - cnt_tol);
+    }
+  }
+  for (auto i = (output.rows()) / 2 + 1; i < output.rows() - 2; ++i)
+  {
+    for (auto j = 0; j < output.cols(); ++j)
+    {
+      accel =  output(i, j) - 2*output(i + 1, j) + output(i + 2, j);
+      EXPECT_TRUE(accel < upper_tol + cnt_tol);
+      EXPECT_TRUE(accel > lower_tol - cnt_tol);
+    }
+  }
 }
 
 int main(int argc, char** argv)

--- a/trajopt/test/costs_unit.launch
+++ b/trajopt/test/costs_unit.launch
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<launch>
+  <include file="$(find trajopt_test_support)/launch/load_arm_around_table.launch" />
+  <test test-name="trajopt_costs_unit" pkg="trajopt" type="trajopt_costs_unit" />
+</launch>

--- a/trajopt_sco/include/trajopt_sco/modeling.hpp
+++ b/trajopt_sco/include/trajopt_sco/modeling.hpp
@@ -144,12 +144,17 @@ class EqConstraint : public Constraint
 {
 public:
   ConstraintType type() { return EQ; }
+  EqConstraint() : Constraint() {}
+  EqConstraint(const string& name) : Constraint(name) {}
+
 };
 
 class IneqConstraint : public Constraint
 {
 public:
   ConstraintType type() { return INEQ; }
+  IneqConstraint() : Constraint() {}
+  IneqConstraint(const string& name) : Constraint(name) {}
 };
 
 /**

--- a/trajopt_sco/include/trajopt_sco/modeling.hpp
+++ b/trajopt_sco/include/trajopt_sco/modeling.hpp
@@ -145,7 +145,7 @@ class EqConstraint : public Constraint
 public:
   ConstraintType type() { return EQ; }
   EqConstraint() : Constraint() {}
-  EqConstraint(const string& name) : Constraint(name) {}
+  EqConstraint(const std::string& name) : Constraint(name) {}
 
 };
 
@@ -154,7 +154,7 @@ class IneqConstraint : public Constraint
 public:
   ConstraintType type() { return INEQ; }
   IneqConstraint() : Constraint() {}
-  IneqConstraint(const string& name) : Constraint(name) {}
+  IneqConstraint(const std::string& name) : Constraint(name) {}
 };
 
 /**

--- a/trajopt_sco/include/trajopt_sco/modeling_utils.hpp
+++ b/trajopt_sco/include/trajopt_sco/modeling_utils.hpp
@@ -103,4 +103,7 @@ protected:
   double epsilon_;
   Eigen::VectorXd scaling_;
 };
+
+std::string AffExprToString(const AffExpr& aff);
+
 }

--- a/trajopt_sco/src/modeling.cpp
+++ b/trajopt_sco/src/modeling.cpp
@@ -81,7 +81,7 @@ void ConvexObjective::removeFromModel()
   model_->removeVars(vars_);
   model_ = NULL;
 }
-double ConvexObjective::value(const vector<double>& x) { return quad_.value(x); }
+double ConvexObjective::value(const DblVec& x) { return quad_.value(x); }
 ConvexObjective::~ConvexObjective()
 {
   if (inModel())

--- a/trajopt_sco/src/modeling.cpp
+++ b/trajopt_sco/src/modeling.cpp
@@ -63,7 +63,6 @@ void ConvexObjective::addMax(const AffExprVector& ev)
     exprDec(ineqs_.back(), m);
   }
 }
-
 void ConvexObjective::addConstraintsToModel()
 {
   cnts_.reserve(eqs_.size() + ineqs_.size());
@@ -76,13 +75,13 @@ void ConvexObjective::addConstraintsToModel()
     cnts_.push_back(model_->addIneqCnt(aff, ""));
   }
 }
-
 void ConvexObjective::removeFromModel()
 {
   model_->removeCnts(cnts_);
   model_->removeVars(vars_);
   model_ = NULL;
 }
+double ConvexObjective::value(const vector<double>& x) { return quad_.value(x); }
 ConvexObjective::~ConvexObjective()
 {
   if (inModel())
@@ -103,7 +102,6 @@ void ConvexConstraints::addConstraintsToModel()
     cnts_.push_back(model_->addIneqCnt(aff, ""));
   }
 }
-
 void ConvexConstraints::removeFromModel()
 {
   model_->removeCnts(cnts_);
@@ -127,7 +125,6 @@ ConvexConstraints::~ConvexConstraints()
     removeFromModel();
 }
 
-double ConvexObjective::value(const DblVec& x) { return quad_.value(x); }
 DblVec Constraint::violations(const DblVec& x)
 {
   DblVec val = value(x);
@@ -146,8 +143,8 @@ DblVec Constraint::violations(const DblVec& x)
 
   return out;
 }
-
 double Constraint::violation(const DblVec& x) { return vecSum(violations(x)); }
+
 OptProb::OptProb() : model_(createModel()) {}
 VarVector OptProb::createVariables(const std::vector<std::string>& var_names)
 {
@@ -245,4 +242,4 @@ DblVec OptProb::getClosestFeasiblePoint(const DblVec& x)
   }
   return model_->getVarValues(vars_);
 }
-}
+}  // namespace sco

--- a/trajopt_sco/src/modeling_utils.cpp
+++ b/trajopt_sco/src/modeling_utils.cpp
@@ -245,4 +245,18 @@ ConvexConstraintsPtr ConstraintFromErrFunc::convex(const DblVec& xin, Model* mod
   }
   return out;
 }
+
+std::string AffExprToString(const AffExpr& aff)
+{
+  std::string out;
+  for(int i = 0; i < aff.vars.size(); i++)
+  {
+    if(i!=0) out.append(" + ");
+    std::string term = std::to_string(aff.coeffs[i]) + "*" + aff.vars[i].var_rep->name;
+    out.append(term);
+  }
+  out.append(" + " + std::to_string(aff.constant));
+  return out;
+}
+
 }

--- a/trajopt_utils/include/trajopt_utils/eigen_conversions.hpp
+++ b/trajopt_utils/include/trajopt_utils/eigen_conversions.hpp
@@ -5,7 +5,7 @@
 
 namespace util
 {
-inline std::vector<double> toDblVec(const Eigen::VectorXd& x)
+inline std::vector<double> toDblVec(const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>& x)
 {
   return std::vector<double>(x.data(), x.data() + x.size());
 }

--- a/trajopt_utils/include/trajopt_utils/vector_ops.hpp
+++ b/trajopt_utils/include/trajopt_utils/vector_ops.hpp
@@ -9,4 +9,10 @@ std::vector<int> arange(int n)
     out[i] = i;
   return out;
 }
+
+inline bool doubleEquals(double x, double y, double eps = 1E-5)
+{
+ return std::abs(x-y) < eps;
+}
+
 }


### PR DESCRIPTION
@Levi-Armstrong I wanted to get your thoughts on this. Currently only joint velocity eq/ineq cost/cnt are implemented. Once we get that the way we like, I figured it will be easy to copy for the others.

The term is centered about targs. If no limits are given, it is an equality term. If limits are given, then it is an iequality term with the hinges at targ+upper_lim and targ+lower_lim (lower_lim should be negative). It seems to pass all of the current tests, but I don't think the inequality is really being tested anywhere.

Still TODO:
- first_step/last_step is unimplemented
- Probably need some checks to make sure limits are correct sign
- Expand to the rest of the terms