### PR TITLE
Add EIGEN_MAKE_ALIGNED_OPERATOR_NEW macro

### DIFF
--- a/trajopt/include/trajopt/kinematic_terms.hpp
+++ b/trajopt/include/trajopt/kinematic_terms.hpp
@@ -19,6 +19,7 @@ typedef BasicArray<Var> VarArray;
  */
 struct DynamicCartPoseErrCalculator : public TrajOptVectorOfVector
 {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   std::string target_;
   tesseract::BasicKinConstPtr manip_;
   tesseract::BasicEnvConstPtr env_;
@@ -44,6 +45,7 @@ struct DynamicCartPoseErrCalculator : public TrajOptVectorOfVector
  */
 struct CartPoseErrCalculator : public TrajOptVectorOfVector
 {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   Eigen::Isometry3d pose_inv_;
   tesseract::BasicKinConstPtr manip_;
   tesseract::BasicEnvConstPtr env_;
@@ -69,6 +71,7 @@ struct CartPoseErrCalculator : public TrajOptVectorOfVector
  */
 struct CartVelJacCalculator : MatrixOfVector
 {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   tesseract::BasicKinConstPtr manip_;
   tesseract::BasicEnvConstPtr env_;
   std::string link_;
@@ -92,6 +95,7 @@ struct CartVelJacCalculator : MatrixOfVector
  */
 struct CartVelErrCalculator : VectorOfVector
 {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   tesseract::BasicKinConstPtr manip_;
   tesseract::BasicEnvConstPtr env_;
   std::string link_;

--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -168,6 +168,8 @@ private:
 /** @brief This is used when the goal frame is not fixed in space */
 struct DynamicCartPoseTermInfo : public TermInfo, public MakesCost, public MakesConstraint
 {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   /** @brief Timestep at which to apply term */
   int timestep;
   std::string target;
@@ -193,6 +195,8 @@ struct DynamicCartPoseTermInfo : public TermInfo, public MakesCost, public Makes
 */
 struct CartPoseTermInfo : public TermInfo, public MakesCost, public MakesConstraint
 {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   /** @brief Timestep at which to apply term */
   int timestep;
   /** @brief  Cartesian position */


### PR DESCRIPTION
I ran into this issue on 32 bit machines but did think it was an issue on 64 bit machines for some reason. I thing I have all of the struct/classes that have fixed size eigen member variables.

@mpowelson You may give the package a once over along with tesseract looking for classes/structs that have fixed size eigen member types.