### PR TITLE
Remove the use of 'using namespace'

### DIFF
--- a/trajopt/include/trajopt/collision_terms.hpp
+++ b/trajopt/include/trajopt/collision_terms.hpp
@@ -17,12 +17,12 @@ struct CollisionEvaluator
   {
   }
   virtual ~CollisionEvaluator() {}
-  virtual void CalcDistExpressions(const DblVec& x, vector<AffExpr>& exprs) = 0;
+  virtual void CalcDistExpressions(const DblVec& x, sco::AffExprVector& exprs) = 0;
   virtual void CalcDists(const DblVec& x, DblVec& exprs) = 0;
   virtual void CalcCollisions(const DblVec& x, tesseract::ContactResultVector& dist_results) = 0;
   void GetCollisionsCached(const DblVec& x, tesseract::ContactResultVector&);
   virtual void Plot(const tesseract::BasicPlottingPtr plotter, const DblVec& x) = 0;
-  virtual VarVector GetVars() = 0;
+  virtual sco::VarVector GetVars() = 0;
 
   const SafetyMarginDataConstPtr getSafetyMarginData() const { return safety_margin_data_; }
   Cache<size_t, tesseract::ContactResultVector, 10> m_cache;
@@ -44,7 +44,7 @@ public:
   SingleTimestepCollisionEvaluator(tesseract::BasicKinConstPtr manip,
                                    tesseract::BasicEnvConstPtr env,
                                    SafetyMarginDataConstPtr safety_margin_data,
-                                   const VarVector& vars);
+                                   const sco::VarVector& vars);
   /**
   @brief linearize all contact distances in terms of robot dofs
   ;
@@ -52,16 +52,16 @@ public:
   For each contact generated, return a linearization of the signed distance
   function
   */
-  void CalcDistExpressions(const DblVec& x, vector<AffExpr>& exprs);
+  void CalcDistExpressions(const DblVec& x, sco::AffExprVector& exprs);
   /**
    * Same as CalcDistExpressions, but just the distances--not the expressions
    */
   void CalcDists(const DblVec& x, DblVec& exprs);
   void CalcCollisions(const DblVec& x, tesseract::ContactResultVector& dist_results);
   void Plot(const tesseract::BasicPlottingPtr plotter, const DblVec& x);
-  VarVector GetVars() { return m_vars; }
+  sco::VarVector GetVars() { return m_vars; }
 private:
-  VarVector m_vars;
+  sco::VarVector m_vars;
   tesseract::DiscreteContactManagerBasePtr contact_manager_;
 };
 
@@ -71,59 +71,59 @@ public:
   CastCollisionEvaluator(tesseract::BasicKinConstPtr manip,
                          tesseract::BasicEnvConstPtr env,
                          SafetyMarginDataConstPtr safety_margin_data,
-                         const VarVector& vars0,
-                         const VarVector& vars1);
-  void CalcDistExpressions(const DblVec& x, vector<AffExpr>& exprs);
+                         const sco::VarVector& vars0,
+                         const sco::VarVector& vars1);
+  void CalcDistExpressions(const DblVec& x, sco::AffExprVector& exprs);
   void CalcDists(const DblVec& x, DblVec& exprs);
   void CalcCollisions(const DblVec& x, tesseract::ContactResultVector& dist_results);
   void Plot(const tesseract::BasicPlottingPtr plotter, const DblVec& x);
-  VarVector GetVars() { return concat(m_vars0, m_vars1); }
+  sco::VarVector GetVars() { return concat(m_vars0, m_vars1); }
 private:
-  VarVector m_vars0;
-  VarVector m_vars1;
+  sco::VarVector m_vars0;
+  sco::VarVector m_vars1;
   tesseract::ContinuousContactManagerBasePtr contact_manager_;
 };
 
-class TRAJOPT_API CollisionCost : public Cost, public Plotter
+class TRAJOPT_API CollisionCost : public sco::Cost, public Plotter
 {
 public:
   /* constructor for single timestep */
   CollisionCost(tesseract::BasicKinConstPtr manip,
                 tesseract::BasicEnvConstPtr env,
                 SafetyMarginDataConstPtr safety_margin_data,
-                const VarVector& vars);
+                const sco::VarVector& vars);
   /* constructor for cast cost */
   CollisionCost(tesseract::BasicKinConstPtr manip,
                 tesseract::BasicEnvConstPtr env,
                 SafetyMarginDataConstPtr safety_margin_data,
-                const VarVector& vars0,
-                const VarVector& vars1);
-  virtual ConvexObjectivePtr convex(const vector<double>& x, Model* model);
-  virtual double value(const vector<double>&);
+                const sco::VarVector& vars0,
+                const sco::VarVector& vars1);
+  virtual sco::ConvexObjectivePtr convex(const DblVec& x, sco::Model* model);
+  virtual double value(const DblVec&);
   void Plot(const tesseract::BasicPlottingPtr& plotter, const DblVec& x);
-  VarVector getVars() { return m_calc->GetVars(); }
+  sco::VarVector getVars() { return m_calc->GetVars(); }
 private:
   CollisionEvaluatorPtr m_calc;
 };
 
-class TRAJOPT_API CollisionConstraint : public IneqConstraint
+class TRAJOPT_API CollisionConstraint : public sco::IneqConstraint
 {
 public:
   /* constructor for single timestep */
   CollisionConstraint(tesseract::BasicKinConstPtr manip,
                       tesseract::BasicEnvConstPtr env,
                       SafetyMarginDataConstPtr safety_margin_data,
-                      const VarVector& vars);
+                      const sco::VarVector& vars);
   /* constructor for cast cost */
   CollisionConstraint(tesseract::BasicKinConstPtr manip,
                       tesseract::BasicEnvConstPtr env,
                       SafetyMarginDataConstPtr safety_margin_data,
-                      const VarVector& vars0,
-                      const VarVector& vars1);
-  virtual ConvexConstraintsPtr convex(const vector<double>& x, Model* model);
-  virtual DblVec value(const vector<double>&);
+                      const sco::VarVector& vars0,
+                      const sco::VarVector& vars1);
+  virtual sco::ConvexConstraintsPtr convex(const DblVec& x, sco::Model* model);
+  virtual DblVec value(const DblVec&);
   void Plot(const DblVec& x);
-  VarVector getVars() { return m_calc->GetVars(); }
+  sco::VarVector getVars() { return m_calc->GetVars(); }
 private:
   CollisionEvaluatorPtr m_calc;
 };

--- a/trajopt/include/trajopt/file_write_callback.hpp
+++ b/trajopt/include/trajopt/file_write_callback.hpp
@@ -4,6 +4,6 @@
 
 namespace trajopt
 {
-Optimizer::Callback WriteCallback(std::shared_ptr<std::ofstream> file,
-                                  const TrajOptProbPtr& prob);
+sco::Optimizer::Callback WriteCallback(std::shared_ptr<std::ofstream> file,
+                                       const TrajOptProbPtr& prob);
 }

--- a/trajopt/include/trajopt/kinematic_terms.hpp
+++ b/trajopt/include/trajopt/kinematic_terms.hpp
@@ -10,8 +10,6 @@
 
 namespace trajopt
 {
-using namespace sco;
-typedef BasicArray<Var> VarArray;
 
 /**
  * @brief Used to calculate the error for CartPoseTermInfo
@@ -34,9 +32,9 @@ struct DynamicCartPoseErrCalculator : public TrajOptVectorOfVector
   {
   }
 
-  void Plot(const tesseract::BasicPlottingPtr& plotter, const VectorXd& dof_vals) override;
+  void Plot(const tesseract::BasicPlottingPtr& plotter, const Eigen::VectorXd& dof_vals) override;
 
-  VectorXd operator()(const VectorXd& dof_vals) const;
+  Eigen::VectorXd operator()(const Eigen::VectorXd& dof_vals) const;
 };
 
 /**
@@ -60,16 +58,16 @@ struct CartPoseErrCalculator : public TrajOptVectorOfVector
   {
   }
 
-  void Plot(const tesseract::BasicPlottingPtr& plotter, const VectorXd& dof_vals) override;
+  void Plot(const tesseract::BasicPlottingPtr& plotter, const Eigen::VectorXd& dof_vals) override;
 
-  VectorXd operator()(const VectorXd& dof_vals) const;
+  Eigen::VectorXd operator()(const Eigen::VectorXd& dof_vals) const;
 };
 
 /**
  * @brief Used to calculate the jacobian for CartVelTermInfo
  *
  */
-struct CartVelJacCalculator : MatrixOfVector
+struct CartVelJacCalculator : sco::MatrixOfVector
 {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   tesseract::BasicKinConstPtr manip_;
@@ -86,14 +84,14 @@ struct CartVelJacCalculator : MatrixOfVector
   {
   }
 
-  MatrixXd operator()(const VectorXd& dof_vals) const;
+  Eigen::MatrixXd operator()(const Eigen::VectorXd& dof_vals) const;
 };
 
 /**
  * @brief  Used to calculate the error for CartVelTermInfo
  * This is converted to a cost or constraint using TrajOptCostFromErrFunc or TrajOptConstraintFromErrFunc
  */
-struct CartVelErrCalculator : VectorOfVector
+struct CartVelErrCalculator : sco::VectorOfVector
 {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   tesseract::BasicKinConstPtr manip_;
@@ -110,6 +108,6 @@ struct CartVelErrCalculator : VectorOfVector
   {
   }
 
-  VectorXd operator()(const VectorXd& dof_vals) const;
+  Eigen::VectorXd operator()(const Eigen::VectorXd& dof_vals) const;
 };
 }

--- a/trajopt/include/trajopt/plot_callback.hpp
+++ b/trajopt/include/trajopt/plot_callback.hpp
@@ -10,5 +10,5 @@ Returns a callback function suitable for an Optimizer.
 This callback will plot the trajectory (with translucent copies of the robot) as
 well as all of the Cost and Constraint functions with plot methods
 */
-Optimizer::Callback TRAJOPT_API PlotCallback(TrajOptProb& prob, const tesseract::BasicPlottingPtr plotter);
+sco::Optimizer::Callback TRAJOPT_API PlotCallback(TrajOptProb& prob, const tesseract::BasicPlottingPtr plotter);
 }

--- a/trajopt/include/trajopt/trajectory_costs.hpp
+++ b/trajopt/include/trajopt/trajectory_costs.hpp
@@ -10,55 +10,55 @@ Simple quadratic costs on trajectory
 
 namespace trajopt
 {
-class TRAJOPT_API JointPosCost : public Cost
+class TRAJOPT_API JointPosCost : public sco::Cost
 {
 public:
-  JointPosCost(const VarVector& vars, const VectorXd& vals, const VectorXd& coeffs);
-  virtual ConvexObjectivePtr convex(const vector<double>& x, Model* model);
-  virtual double value(const vector<double>&);
+  JointPosCost(const sco::VarVector& vars, const Eigen::VectorXd& vals, const Eigen::VectorXd& coeffs);
+  virtual sco::ConvexObjectivePtr convex(const DblVec& x, sco::Model* model);
+  virtual double value(const DblVec &);
 
 private:
-  VarVector vars_;
-  VectorXd vals_, coeffs_;
-  QuadExpr expr_;
+  sco::VarVector vars_;
+  Eigen::VectorXd vals_, coeffs_;
+  sco::QuadExpr expr_;
 };
 
-class TRAJOPT_API JointVelCost : public Cost
+class TRAJOPT_API JointVelCost : public sco::Cost
 {
 public:
-  JointVelCost(const VarArray& traj, const VectorXd& coeffs);
-  virtual ConvexObjectivePtr convex(const vector<double>& x, Model* model);
-  virtual double value(const vector<double>&);
+  JointVelCost(const VarArray& traj, const Eigen::VectorXd& coeffs);
+  virtual sco::ConvexObjectivePtr convex(const DblVec& x, sco::Model* model);
+  virtual double value(const DblVec&);
 
 private:
   VarArray vars_;
-  VectorXd coeffs_;
-  QuadExpr expr_;
+  Eigen::VectorXd coeffs_;
+  sco::QuadExpr expr_;
 };
 
-class TRAJOPT_API JointAccCost : public Cost
+class TRAJOPT_API JointAccCost : public sco::Cost
 {
 public:
-  JointAccCost(const VarArray& traj, const VectorXd& coeffs);
-  virtual ConvexObjectivePtr convex(const vector<double>& x, Model* model);
-  virtual double value(const vector<double>&);
+  JointAccCost(const VarArray& traj, const Eigen::VectorXd& coeffs);
+  virtual sco::ConvexObjectivePtr convex(const DblVec& x, sco::Model* model);
+  virtual double value(const DblVec&);
 
 private:
   VarArray vars_;
-  VectorXd coeffs_;
-  QuadExpr expr_;
+  Eigen::VectorXd coeffs_;
+  sco::QuadExpr expr_;
 };
 
-class TRAJOPT_API JointJerkCost : public Cost
+class TRAJOPT_API JointJerkCost : public sco::Cost
 {
 public:
-  JointJerkCost(const VarArray& traj, const VectorXd& coeffs);
-  virtual ConvexObjectivePtr convex(const vector<double>& x, Model* model);
-  virtual double value(const vector<double>&);
+  JointJerkCost(const VarArray& traj, const Eigen::VectorXd& coeffs);
+  virtual sco::ConvexObjectivePtr convex(const DblVec& x, sco::Model* model);
+  virtual double value(const DblVec&);
 
 private:
   VarArray vars_;
-  VectorXd coeffs_;
-  QuadExpr expr_;
+  Eigen::VectorXd coeffs_;
+  sco::QuadExpr expr_;
 };
 }

--- a/trajopt/include/trajopt/typedefs.hpp
+++ b/trajopt/include/trajopt/typedefs.hpp
@@ -12,25 +12,15 @@
 
 namespace trajopt
 {
-using std::vector;
-using std::map;
-using namespace sco;
-using namespace util;
 
-typedef BasicArray<Var> VarArray;
-typedef BasicArray<AffExpr> AffArray;
-typedef BasicArray<Cnt> CntArray;
-
-typedef vector<double> DblVec;
-typedef vector<int> IntVec;
-
+typedef util::BasicArray<sco::Var> VarArray;
+typedef util::BasicArray<sco::AffExpr> AffArray;
+typedef util::BasicArray<sco::Cnt> CntArray;
 typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> DblMatrix;
 typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> TrajArray;
-using Eigen::Vector3d;
-using Eigen::Vector4d;
-using Eigen::VectorXd;
-using Eigen::MatrixXd;
-using Eigen::Matrix3d;
+typedef sco::DblVec DblVec;
+typedef sco::IntVec IntVec;
+
 
 /** @brief Interface for objects that know how to plot themselves given solution
  * vector x */
@@ -43,33 +33,33 @@ public:
 typedef std::shared_ptr<Plotter> PlotterPtr;
 
 /**  @brief Adds plotting to the VectorOfVector class in trajopt_sco */
-class TrajOptVectorOfVector : public VectorOfVector
+class TrajOptVectorOfVector : public sco::VectorOfVector
 {
 public:
-  virtual void Plot(const tesseract::BasicPlottingPtr& plotter, const VectorXd& dof_vals) = 0;
+  virtual void Plot(const tesseract::BasicPlottingPtr& plotter, const Eigen::VectorXd& dof_vals) = 0;
 };
 
 /**  @brief Adds plotting to the CostFromErrFunc class in trajopt_sco */
-class TrajOptCostFromErrFunc : public CostFromErrFunc, public Plotter
+class TrajOptCostFromErrFunc : public sco::CostFromErrFunc, public Plotter
 {
 public:
   /// supply error function, obtain derivative numerically
-  TrajOptCostFromErrFunc(VectorOfVectorPtr f,
-                         const VarVector& vars,
-                         const VectorXd& coeffs,
-                         PenaltyType pen_type,
+  TrajOptCostFromErrFunc(sco::VectorOfVectorPtr f,
+                         const sco::VarVector& vars,
+                         const Eigen::VectorXd& coeffs,
+                         sco::PenaltyType pen_type,
                          const std::string& name)
     : CostFromErrFunc(f, vars, coeffs, pen_type, name)
   {
   }
 
   /// supply error function and gradient
-  TrajOptCostFromErrFunc(VectorOfVectorPtr f,
-                         MatrixOfVectorPtr dfdx,
-                         const VarVector& vars,
-                         const VectorXd& coeffs,
-                         PenaltyType pen_type,
-                         const string& name)
+  TrajOptCostFromErrFunc(sco::VectorOfVectorPtr f,
+                         sco::MatrixOfVectorPtr dfdx,
+                         const sco::VarVector& vars,
+                         const Eigen::VectorXd& coeffs,
+                         sco::PenaltyType pen_type,
+                         const std::string& name)
     : CostFromErrFunc(f, dfdx, vars, coeffs, pen_type, name)
   {
   }
@@ -79,32 +69,32 @@ public:
     // If error function has a inherited from TrajOptVectorOfVector, call its Plot function
     if (TrajOptVectorOfVector* plt = dynamic_cast<TrajOptVectorOfVector*>(f_.get()))
     {
-      VectorXd dof_vals = getVec(x, vars_);
+      Eigen::VectorXd dof_vals = sco::getVec(x, vars_);
       plt->Plot(plotter, dof_vals);
     }
   }
 };
 
 /**  @brief Adds plotting to the ConstraintFromFunc class in trajopt_sco */
-class TrajOptConstraintFromErrFunc : public ConstraintFromErrFunc, public Plotter
+class TrajOptConstraintFromErrFunc : public sco::ConstraintFromErrFunc, public Plotter
 {
 public:
   /// supply error function, obtain derivative numerically
-  TrajOptConstraintFromErrFunc(VectorOfVectorPtr f,
-                            const VarVector& vars,
-                            const VectorXd& coeffs,
-                            ConstraintType type,
+  TrajOptConstraintFromErrFunc(sco::VectorOfVectorPtr f,
+                            const sco::VarVector& vars,
+                            const Eigen::VectorXd& coeffs,
+                            sco::ConstraintType type,
                             const std::string& name)
     : ConstraintFromErrFunc(f, vars, coeffs, type, name)
   {
   }
 
   /// supply error function and gradient
-  TrajOptConstraintFromErrFunc(VectorOfVectorPtr f,
-                            MatrixOfVectorPtr dfdx,
-                            const VarVector& vars,
-                            const VectorXd& coeffs,
-                            ConstraintType type,
+  TrajOptConstraintFromErrFunc(sco::VectorOfVectorPtr f,
+                            sco::MatrixOfVectorPtr dfdx,
+                            const sco::VarVector& vars,
+                            const Eigen::VectorXd& coeffs,
+                            sco::ConstraintType type,
                             const std::string& name)
     : ConstraintFromErrFunc(f, dfdx, vars, coeffs, type, name)
   {
@@ -115,7 +105,7 @@ public:
     // If error function has a inherited from TrajOptVectorOfVector, call its Plot function
     if (TrajOptVectorOfVector* plt = dynamic_cast<TrajOptVectorOfVector*>(f_.get()))
     {
-      VectorXd dof_vals = getVec(x, vars_);
+      Eigen::VectorXd dof_vals = sco::getVec(x, vars_);
       plt->Plot(plotter, dof_vals);
     }
   }

--- a/trajopt/include/trajopt/utils.hpp
+++ b/trajopt/include/trajopt/utils.hpp
@@ -11,41 +11,42 @@ TrajArray TRAJOPT_API getTraj(const DblVec& x, const VarArray& vars);
 TrajArray TRAJOPT_API getTraj(const DblVec& x, const AffArray& arr);
 
 inline DblVec trajToDblVec(const TrajArray& x) { return DblVec(x.data(), x.data() + x.rows() * x.cols()); }
-inline VectorXd concat(const VectorXd& a, const VectorXd& b)
+inline Eigen::VectorXd concat(const Eigen::VectorXd& a, const Eigen::VectorXd& b)
 {
-  VectorXd out(a.size() + b.size());
+  Eigen::VectorXd out(a.size() + b.size());
   out.topRows(a.size()) = a;
   out.middleRows(a.size(), b.size()) = b;
   return out;
 }
 
 template <typename T>
-vector<T> concat(const vector<T>& a, const vector<T>& b)
+std::vector<T> concat(const std::vector<T>& a, const std::vector<T>& b)
 {
-  vector<T> out;
-  vector<int> x;
+  std::vector<T> out;
+  std::vector<int> x;
   out.insert(out.end(), a.begin(), a.end());
   out.insert(out.end(), b.begin(), b.end());
   return out;
 }
 
 template <typename T>
-vector<T> singleton(const T& x)
+std::vector<T> singleton(const T& x)
 {
-  return vector<T>(1, x);
+  return std::vector<T>(1, x);
 }
 
-void TRAJOPT_API AddVarArrays(OptProb& prob,
+void TRAJOPT_API AddVarArrays(sco::OptProb& prob,
                               int rows,
-                              const vector<int>& cols,
-                              const vector<string>& name_prefix,
-                              const vector<VarArray*>& newvars);
+                              const std::vector<int>& cols,
+                              const std::vector<std::string>& name_prefix,
+                              const std::vector<VarArray*>& newvars);
 
-void TRAJOPT_API AddVarArray(OptProb& prob, int rows, int cols, const string& name_prefix, VarArray& newvars);
+void TRAJOPT_API AddVarArray(sco::OptProb& prob, int rows, int cols, const std::string& name_prefix, VarArray& newvars);
 
 /** @brief Store Safety Margin Data for a given timestep */
 struct SafetyMarginData
 {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   SafetyMarginData(const double& default_safety_margin, const double& default_safety_margin_coeff)
     : default_safety_margin_data_(default_safety_margin, default_safety_margin_coeff)
     , max_safety_margin_(default_safety_margin)

--- a/trajopt/src/json_marshal.cpp
+++ b/trajopt/src/json_marshal.cpp
@@ -1,9 +1,6 @@
 #include <jsoncpp/json/json.h>
 #include <stdexcept>
 #include <trajopt/json_marshal.hpp>
-using namespace Json;
-using namespace std;
-
 namespace json_marshal
 {
 void fromJson(const Json::Value& v, bool& ref)
@@ -56,14 +53,14 @@ void fromJson(const Json::Value& v, std::string& ref)
 
 void fromJson(const Json::Value& v, Eigen::Vector3d& ref)
 {
-  vector<double> vx;
+  std::vector<double> vx;
   fromJsonArray(v, vx, 3);
   ref = Eigen::Vector3d(vx[0], vx[1], vx[2]);
 }
 
 void fromJson(const Json::Value& v, Eigen::Vector4d& ref)
 {
-  vector<double> vx;
+  std::vector<double> vx;
   fromJsonArray(v, vx, 4);
   ref = Eigen::Vector4d(vx[0], vx[1], vx[2], vx[3]);
 }

--- a/trajopt/src/plot_callback.cpp
+++ b/trajopt/src/plot_callback.cpp
@@ -7,20 +7,18 @@
 #include <trajopt/problem_description.hpp>
 #include <trajopt_utils/eigen_conversions.hpp>
 
-using namespace util;
-using namespace std;
 namespace trajopt
 {
 void PlotCosts(const tesseract::BasicPlottingPtr plotter,
                const std::vector<std::string>& joint_names,
-               const vector<CostPtr>& costs,
-               const vector<ConstraintPtr>& cnts,
+               const std::vector<sco::CostPtr>& costs,
+               const std::vector<sco::ConstraintPtr>& cnts,
                const VarArray& vars,
-               const OptResults& results)
+               const sco::OptResults& results)
 {
   plotter->clear();
 
-  for (const CostPtr& cost : costs)
+  for (const sco::CostPtr& cost : costs)
   {
     if (Plotter* plt = dynamic_cast<Plotter*>(cost.get()))
     {
@@ -28,7 +26,7 @@ void PlotCosts(const tesseract::BasicPlottingPtr plotter,
     }
   }
 
-  for (const ConstraintPtr& cnt : cnts)
+  for (const sco::ConstraintPtr& cnt : cnts)
   {
     if (Plotter* plt = dynamic_cast<Plotter*>(cnt.get()))
     {
@@ -40,9 +38,9 @@ void PlotCosts(const tesseract::BasicPlottingPtr plotter,
   plotter->waitForInput();
 }
 
-Optimizer::Callback PlotCallback(TrajOptProb& prob, const tesseract::BasicPlottingPtr plotter)
+sco::Optimizer::Callback PlotCallback(TrajOptProb& prob, const tesseract::BasicPlottingPtr plotter)
 {
-  vector<ConstraintPtr> cnts = prob.getConstraints();
+  std::vector<sco::ConstraintPtr> cnts = prob.getConstraints();
   return std::bind(&PlotCosts,
                    plotter,
                    prob.GetKin()->getJointNames(),

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -13,16 +13,11 @@
 #include <trajopt_utils/logging.hpp>
 #include <ros/ros.h>
 
-using namespace Json;
-using namespace std;
-using namespace trajopt;
-using namespace util;
-
 namespace
 {
 bool gRegisteredMakers = false;
 
-void ensure_only_members(const Value& v, const char** fields, int nvalid)
+void ensure_only_members(const Json::Value& v, const char** fields, int nvalid)
 {
   for (Json::ValueConstIterator it = v.begin(); it != v.end(); ++it)
   {
@@ -45,31 +40,31 @@ void ensure_only_members(const Value& v, const char** fields, int nvalid)
 
 void RegisterMakers()
 {
-  TermInfo::RegisterMaker("dynamic_cart_pose", &DynamicCartPoseTermInfo::create);
-  TermInfo::RegisterMaker("cart_pose", &CartPoseTermInfo::create);
-  TermInfo::RegisterMaker("cart_vel", &CartVelTermInfo::create);
-  TermInfo::RegisterMaker("joint_pos", &JointPosTermInfo::create);
-  TermInfo::RegisterMaker("joint_vel", &JointVelTermInfo::create);
-  TermInfo::RegisterMaker("joint_acc", &JointAccTermInfo::create);
-  TermInfo::RegisterMaker("joint_jerk", &JointJerkTermInfo::create);
-  TermInfo::RegisterMaker("collision", &CollisionTermInfo::create);
+  trajopt::TermInfo::RegisterMaker("dynamic_cart_pose", &trajopt::DynamicCartPoseTermInfo::create);
+  trajopt::TermInfo::RegisterMaker("cart_pose", &trajopt::CartPoseTermInfo::create);
+  trajopt::TermInfo::RegisterMaker("cart_vel", &trajopt::CartVelTermInfo::create);
+  trajopt::TermInfo::RegisterMaker("joint_pos", &trajopt::JointPosTermInfo::create);
+  trajopt::TermInfo::RegisterMaker("joint_vel", &trajopt::JointVelTermInfo::create);
+  trajopt::TermInfo::RegisterMaker("joint_acc", &trajopt::JointAccTermInfo::create);
+  trajopt::TermInfo::RegisterMaker("joint_jerk", &trajopt::JointJerkTermInfo::create);
+  trajopt::TermInfo::RegisterMaker("collision", &trajopt::CollisionTermInfo::create);
 
   gRegisteredMakers = true;
 }
 
-PenaltyType stringToPenaltyType(string str)
+sco::PenaltyType stringToPenaltyType(std::string str)
 {
   if (boost::iequals(str, "hinge"))
   {
-    return HINGE;
+    return sco::HINGE;
   }
   else if (boost::iequals(str, "abs"))
   {
-    return ABS;
+    return sco::ABS;
   }
   else if (boost::iequals(str, "squared"))
   {
-    return SQUARED;
+    return sco::SQUARED;
   }
   else
   {
@@ -88,9 +83,9 @@ BoolVec toMask(const VectorXd& x) {
 
 namespace trajopt
 {
-std::map<string, TermInfo::MakerFunc> TermInfo::name2maker;
+std::map<std::string, TermInfo::MakerFunc> TermInfo::name2maker;
 void TermInfo::RegisterMaker(const std::string& type, MakerFunc f) { name2maker[type] = f; }
-TermInfoPtr TermInfo::fromName(const string& type)
+TermInfoPtr TermInfo::fromName(const std::string& type)
 {
   if (!gRegisteredMakers)
     RegisterMakers();
@@ -105,42 +100,41 @@ TermInfoPtr TermInfo::fromName(const string& type)
   }
 }
 
-void ProblemConstructionInfo::readBasicInfo(const Value& v)
+void ProblemConstructionInfo::readBasicInfo(const Json::Value& v)
 {
-  childFromJson(v, basic_info.start_fixed, "start_fixed", true);
-  childFromJson(v, basic_info.n_steps, "n_steps");
-  childFromJson(v, basic_info.manip, "manip");
-  childFromJson(v, basic_info.robot, "robot", string(""));
-  childFromJson(v, basic_info.dofs_fixed, "dofs_fixed", IntVec());
+  json_marshal::childFromJson(v, basic_info.start_fixed, "start_fixed", true);
+  json_marshal::childFromJson(v, basic_info.n_steps, "n_steps");
+  json_marshal::childFromJson(v, basic_info.manip, "manip");
+  json_marshal::childFromJson(v, basic_info.robot, "robot", std::string(""));
+  json_marshal::childFromJson(v, basic_info.dofs_fixed, "dofs_fixed", IntVec());
   // TODO: optimization parameters, etc?
 }
 
-void ProblemConstructionInfo::readOptInfo(const Value& v)
+void ProblemConstructionInfo::readOptInfo(const Json::Value& v)
 {
-  childFromJson(v, opt_info.improve_ratio_threshold, "improve_ratio_threshold", opt_info.improve_ratio_threshold);
-  childFromJson(v, opt_info.min_trust_box_size, "min_trust_box_size", opt_info.min_trust_box_size);
-  childFromJson(v, opt_info.min_approx_improve, "min_approx_improve", opt_info.min_approx_improve);
-  childFromJson(v, opt_info.min_approx_improve_frac, "min_approx_improve_frac", opt_info.min_approx_improve_frac);
-  childFromJson(v, opt_info.max_iter, "max_iter", opt_info.max_iter);
-  childFromJson(v, opt_info.trust_shrink_ratio, "trust_shrink_ratio", opt_info.trust_shrink_ratio);
-  childFromJson(v, opt_info.trust_expand_ratio, "trust_expand_ratio", opt_info.trust_expand_ratio);
-  childFromJson(v, opt_info.cnt_tolerance, "cnt_tolerance", opt_info.cnt_tolerance);
-  childFromJson(v, opt_info.max_merit_coeff_increases, "max_merit_coeff_increases", opt_info.max_merit_coeff_increases);
-  childFromJson(
-      v, opt_info.merit_coeff_increase_ratio, "merit_coeff_increase_ratio", opt_info.merit_coeff_increase_ratio);
-  childFromJson(v, opt_info.max_time, "max_time", opt_info.max_time);
-  childFromJson(v, opt_info.merit_error_coeff, "merit_error_coeff", opt_info.merit_error_coeff);
-  childFromJson(v, opt_info.trust_box_size, "trust_box_size", opt_info.trust_box_size);
+  json_marshal::childFromJson(v, opt_info.improve_ratio_threshold, "improve_ratio_threshold", opt_info.improve_ratio_threshold);
+  json_marshal::childFromJson(v, opt_info.min_trust_box_size, "min_trust_box_size", opt_info.min_trust_box_size);
+  json_marshal::childFromJson(v, opt_info.min_approx_improve, "min_approx_improve", opt_info.min_approx_improve);
+  json_marshal::childFromJson(v, opt_info.min_approx_improve_frac, "min_approx_improve_frac", opt_info.min_approx_improve_frac);
+  json_marshal::childFromJson(v, opt_info.max_iter, "max_iter", opt_info.max_iter);
+  json_marshal::childFromJson(v, opt_info.trust_shrink_ratio, "trust_shrink_ratio", opt_info.trust_shrink_ratio);
+  json_marshal::childFromJson(v, opt_info.trust_expand_ratio, "trust_expand_ratio", opt_info.trust_expand_ratio);
+  json_marshal::childFromJson(v, opt_info.cnt_tolerance, "cnt_tolerance", opt_info.cnt_tolerance);
+  json_marshal::childFromJson(v, opt_info.max_merit_coeff_increases, "max_merit_coeff_increases", opt_info.max_merit_coeff_increases);
+  json_marshal::childFromJson(v, opt_info.merit_coeff_increase_ratio, "merit_coeff_increase_ratio", opt_info.merit_coeff_increase_ratio);
+  json_marshal::childFromJson(v, opt_info.max_time, "max_time", opt_info.max_time);
+  json_marshal::childFromJson(v, opt_info.merit_error_coeff, "merit_error_coeff", opt_info.merit_error_coeff);
+  json_marshal::childFromJson(v, opt_info.trust_box_size, "trust_box_size", opt_info.trust_box_size);
 }
 
-void ProblemConstructionInfo::readCosts(const Value& v)
+void ProblemConstructionInfo::readCosts(const Json::Value& v)
 {
   cost_infos.clear();
   cost_infos.reserve(v.size());
   for (Json::Value::const_iterator it = v.begin(); it != v.end(); ++it)
   {
-    string type;
-    childFromJson(*it, type, "type");
+    std::string type;
+    json_marshal::childFromJson(*it, type, "type");
     LOG_DEBUG("reading term: %s", type.c_str());
     TermInfoPtr term = TermInfo::fromName(type);
 
@@ -151,20 +145,20 @@ void ProblemConstructionInfo::readCosts(const Value& v)
     term->term_type = TT_COST;
 
     term->fromJson(*this, *it);
-    childFromJson(*it, term->name, "name", type);
+    json_marshal::childFromJson(*it, term->name, "name", type);
 
     cost_infos.push_back(term);
   }
 }
 
-void ProblemConstructionInfo::readConstraints(const Value& v)
+void ProblemConstructionInfo::readConstraints(const Json::Value& v)
 {
   cnt_infos.clear();
   cnt_infos.reserve(v.size());
   for (Json::Value::const_iterator it = v.begin(); it != v.end(); ++it)
   {
-    string type;
-    childFromJson(*it, type, "type");
+    std::string type;
+    json_marshal::childFromJson(*it, type, "type");
     LOG_DEBUG("reading term: %s", type.c_str());
     TermInfoPtr term = TermInfo::fromName(type);
 
@@ -175,16 +169,16 @@ void ProblemConstructionInfo::readConstraints(const Value& v)
     term->term_type = TT_CNT;
 
     term->fromJson(*this, *it);
-    childFromJson(*it, term->name, "name", type);
+    json_marshal::childFromJson(*it, term->name, "name", type);
 
     cnt_infos.push_back(term);
   }
 }
 
-void ProblemConstructionInfo::readInitInfo(const Value& v)
+void ProblemConstructionInfo::readInitInfo(const Json::Value& v)
 {
-  string type_str;
-  childFromJson(v, type_str, "type");
+  std::string type_str;
+  json_marshal::childFromJson(v, type_str, "type");
   int n_steps = basic_info.n_steps;
   int n_dof = kin->numJoints();
   Eigen::VectorXd start_pos = env->getCurrentJointValues(kin->getName());
@@ -196,7 +190,7 @@ void ProblemConstructionInfo::readInitInfo(const Value& v)
   else if (type_str == "given_traj")
   {
     FAIL_IF_FALSE(v.isMember("data"));
-    const Value& vdata = v["data"];
+    const Json::Value& vdata = v["data"];
     if (static_cast<int>(vdata.size()) != n_steps)
     {
       PRINT_AND_THROW("given initialization traj has wrong length");
@@ -205,15 +199,15 @@ void ProblemConstructionInfo::readInitInfo(const Value& v)
     for (int i = 0; i < n_steps; ++i)
     {
       DblVec row;
-      fromJsonArray(vdata[i], row, n_dof);
-      init_info.data.row(i) = toVectorXd(row);
+      json_marshal::fromJsonArray(vdata[i], row, n_dof);
+      init_info.data.row(i) = util::toVectorXd(row);
     }
   }
   else if (type_str == "straight_line")
   {
     FAIL_IF_FALSE(v.isMember("endpoint"));
     DblVec endpoint;
-    childFromJson(v, endpoint, "endpoint");
+    json_marshal::childFromJson(v, endpoint, "endpoint");
     if (static_cast<int>(endpoint.size()) != n_dof)
     {
       PRINT_AND_THROW(boost::format("wrong number of dof values in "
@@ -223,12 +217,12 @@ void ProblemConstructionInfo::readInitInfo(const Value& v)
     init_info.data = TrajArray(n_steps, n_dof);
     for (int idof = 0; idof < n_dof; ++idof)
     {
-      init_info.data.col(idof) = VectorXd::LinSpaced(n_steps, start_pos[idof], endpoint[idof]);
+      init_info.data.col(idof) = Eigen::VectorXd::LinSpaced(n_steps, start_pos[idof], endpoint[idof]);
     }
   }
 }
 
-void ProblemConstructionInfo::fromJson(const Value& v)
+void ProblemConstructionInfo::fromJson(const Json::Value& v)
 {
   if (v.isMember("basic_info"))
   {
@@ -265,14 +259,14 @@ void ProblemConstructionInfo::fromJson(const Value& v)
   }
 }
 
-TrajOptResult::TrajOptResult(OptResults& opt, TrajOptProb& prob) : cost_vals(opt.cost_vals), cnt_viols(opt.cnt_viols)
+TrajOptResult::TrajOptResult(sco::OptResults& opt, TrajOptProb& prob) : cost_vals(opt.cost_vals), cnt_viols(opt.cnt_viols)
 {
-  for (const CostPtr& cost : prob.getCosts())
+  for (const sco::CostPtr& cost : prob.getCosts())
   {
     cost_names.push_back(cost->name());
   }
 
-  for (const ConstraintPtr& cnt : prob.getConstraints())
+  for (const sco::ConstraintPtr& cnt : prob.getConstraints())
   {
     cnt_names.push_back(cnt->name());
   }
@@ -282,8 +276,8 @@ TrajOptResult::TrajOptResult(OptResults& opt, TrajOptProb& prob) : cost_vals(opt
 
 TrajOptResultPtr OptimizeProblem(TrajOptProbPtr prob, const tesseract::BasicPlottingPtr plotter)
 {
-  BasicTrustRegionSQP opt(prob);
-  BasicTrustRegionSQPParameters& param = opt.getParameters();
+  sco::BasicTrustRegionSQP opt(prob);
+  sco::BasicTrustRegionSQPParameters& param = opt.getParameters();
   param.max_iter = 40;
   param.min_approx_improve_frac = .001;
   param.improve_ratio_threshold = .2;
@@ -318,7 +312,7 @@ TrajOptProbPtr ConstructProblem(const ProblemConstructionInfo& pci)
 
     for (int j = 0; j < n_dof; ++j)
     {
-      prob->addLinearConstraint(exprSub(AffExpr(prob->m_traj_vars(0, j)), pci.init_info.data(0, j)), EQ);
+      prob->addLinearConstraint(sco::exprSub(sco::AffExpr(prob->m_traj_vars(0, j)), pci.init_info.data(0, j)), sco::EQ);
     }
   }
 
@@ -328,8 +322,7 @@ TrajOptProbPtr ConstructProblem(const ProblemConstructionInfo& pci)
     {
       for (int i = 1; i < prob->GetNumSteps(); ++i)
       {
-        prob->addLinearConstraint(
-            exprSub(AffExpr(prob->m_traj_vars(i, dof_ind)), AffExpr(prob->m_traj_vars(0, dof_ind))), EQ);
+        prob->addLinearConstraint(sco::exprSub(sco::AffExpr(prob->m_traj_vars(i, dof_ind)), sco::AffExpr(prob->m_traj_vars(0, dof_ind))), sco::EQ);
       }
     }
   }
@@ -364,8 +357,8 @@ TrajOptProb::TrajOptProb(int n_steps, const ProblemConstructionInfo& pci) : m_ki
   lower = limits.col(0);
   upper = limits.col(1);
 
-  vector<double> vlower, vupper;
-  vector<string> names;
+  DblVec vlower, vupper;
+  std::vector<std::string> names;
   for (int i = 0; i < n_steps; ++i)
   {
     vlower.insert(vlower.end(), lower.data(), lower.data() + lower.size());
@@ -375,7 +368,7 @@ TrajOptProb::TrajOptProb(int n_steps, const ProblemConstructionInfo& pci) : m_ki
       names.push_back((boost::format("j_%i_%i") % i % j).str());
     }
   }
-  VarVector trajvarvec = createVariables(names, vlower, vupper);
+  sco::VarVector trajvarvec = createVariables(names, vlower, vupper);
   m_traj_vars = VarArray(n_steps, n_dof, trajvarvec.data());
 }
 
@@ -383,25 +376,25 @@ TrajOptProb::TrajOptProb() {}
 
 DynamicCartPoseTermInfo::DynamicCartPoseTermInfo()
 {
-  pos_coeffs = Vector3d::Ones();
-  rot_coeffs = Vector3d::Ones();
+  pos_coeffs = Eigen::Vector3d::Ones();
+  rot_coeffs = Eigen::Vector3d::Ones();
   tcp.setIdentity();
 }
 
-void DynamicCartPoseTermInfo::fromJson(ProblemConstructionInfo& pci, const Value& v)
+void DynamicCartPoseTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value& v)
 {
   FAIL_IF_FALSE(v.isMember("params"));
-  Vector3d tcp_xyz = Vector3d::Zero();
-  Vector4d tcp_wxyz = Vector4d(1, 0, 0, 0);
+  Eigen::Vector3d tcp_xyz = Eigen::Vector3d::Zero();
+  Eigen::Vector4d tcp_wxyz = Eigen::Vector4d(1, 0, 0, 0);
 
-  const Value& params = v["params"];
-  childFromJson(params, timestep, "timestep", pci.basic_info.n_steps - 1);
-  childFromJson(params, target, "target");
-  childFromJson(params, pos_coeffs, "pos_coeffs", (Vector3d)Vector3d::Ones());
-  childFromJson(params, rot_coeffs, "rot_coeffs", (Vector3d)Vector3d::Ones());
-  childFromJson(params, link, "link");
-  childFromJson(params, tcp_xyz, "tcp_xyz", (Vector3d)Vector3d::Zero());
-  childFromJson(params, tcp_wxyz, "tcp_wxyz", (Vector4d)Vector4d(1, 0, 0, 0));
+  const Json::Value& params = v["params"];
+  json_marshal::childFromJson(params, timestep, "timestep", pci.basic_info.n_steps - 1);
+  json_marshal::childFromJson(params, target, "target");
+  json_marshal::childFromJson(params, pos_coeffs, "pos_coeffs", Eigen::Vector3d(1, 1, 1));
+  json_marshal::childFromJson(params, rot_coeffs, "rot_coeffs", Eigen::Vector3d(1, 1, 1));
+  json_marshal::childFromJson(params, link, "link");
+  json_marshal::childFromJson(params, tcp_xyz, "tcp_xyz", Eigen::Vector3d(0, 0, 0));
+  json_marshal::childFromJson(params, tcp_wxyz, "tcp_wxyz", Eigen::Vector4d(1, 0, 0, 0));
 
   Eigen::Quaterniond q(tcp_wxyz(0), tcp_wxyz(1), tcp_wxyz(2), tcp_wxyz(3));
   tcp.linear() = q.matrix();
@@ -419,16 +412,14 @@ void DynamicCartPoseTermInfo::fromJson(ProblemConstructionInfo& pci, const Value
 
 void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
 {
-  VectorOfVectorPtr f(new DynamicCartPoseErrCalculator(target, prob.GetKin(), prob.GetEnv(), link, tcp));
+  sco::VectorOfVectorPtr f(new DynamicCartPoseErrCalculator(target, prob.GetKin(), prob.GetEnv(), link, tcp));
   if (term_type == TT_COST)
   {
-    prob.addCost(
-        CostPtr(new TrajOptCostFromErrFunc(f, prob.GetVarRow(timestep), concat(rot_coeffs, pos_coeffs), ABS, name)));
+    prob.addCost(sco::CostPtr(new TrajOptCostFromErrFunc(f, prob.GetVarRow(timestep), concat(rot_coeffs, pos_coeffs), sco::ABS, name)));
   }
   else if (term_type == TT_CNT)
   {
-    prob.addConstraint(ConstraintPtr(
-        new TrajOptConstraintFromErrFunc(f, prob.GetVarRow(timestep), concat(rot_coeffs, pos_coeffs), EQ, name)));
+    prob.addConstraint(sco::ConstraintPtr(new TrajOptConstraintFromErrFunc(f, prob.GetVarRow(timestep), concat(rot_coeffs, pos_coeffs), sco::EQ, name)));
   }
   else
   {
@@ -438,26 +429,26 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
 
 CartPoseTermInfo::CartPoseTermInfo()
 {
-  pos_coeffs = Vector3d::Ones();
-  rot_coeffs = Vector3d::Ones();
+  pos_coeffs = Eigen::Vector3d::Ones();
+  rot_coeffs = Eigen::Vector3d::Ones();
   tcp.setIdentity();
 }
 
-void CartPoseTermInfo::fromJson(ProblemConstructionInfo& pci, const Value& v)
+void CartPoseTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value& v)
 {
   FAIL_IF_FALSE(v.isMember("params"));
-  Vector3d tcp_xyz = Vector3d::Zero();
-  Vector4d tcp_wxyz = Vector4d(1, 0, 0, 0);
+  Eigen::Vector3d tcp_xyz = Eigen::Vector3d::Zero();
+  Eigen::Vector4d tcp_wxyz = Eigen::Vector4d(1, 0, 0, 0);
 
-  const Value& params = v["params"];
-  childFromJson(params, timestep, "timestep", pci.basic_info.n_steps - 1);
-  childFromJson(params, xyz, "xyz");
-  childFromJson(params, wxyz, "wxyz");
-  childFromJson(params, pos_coeffs, "pos_coeffs", (Vector3d)Vector3d::Ones());
-  childFromJson(params, rot_coeffs, "rot_coeffs", (Vector3d)Vector3d::Ones());
-  childFromJson(params, link, "link");
-  childFromJson(params, tcp_xyz, "tcp_xyz", (Vector3d)Vector3d::Zero());
-  childFromJson(params, tcp_wxyz, "tcp_wxyz", (Vector4d)Vector4d(1, 0, 0, 0));
+  const Json::Value& params = v["params"];
+  json_marshal::childFromJson(params, timestep, "timestep", pci.basic_info.n_steps - 1);
+  json_marshal::childFromJson(params, xyz, "xyz");
+  json_marshal::childFromJson(params, wxyz, "wxyz");
+  json_marshal::childFromJson(params, pos_coeffs, "pos_coeffs", Eigen::Vector3d(1, 1, 1));
+  json_marshal::childFromJson(params, rot_coeffs, "rot_coeffs", Eigen::Vector3d(1, 1, 1));
+  json_marshal::childFromJson(params, link, "link");
+  json_marshal::childFromJson(params, tcp_xyz, "tcp_xyz", Eigen::Vector3d(0, 0, 0));
+  json_marshal::childFromJson(params, tcp_wxyz, "tcp_wxyz", Eigen::Vector4d(1, 0, 0, 0));
 
   Eigen::Quaterniond q(tcp_wxyz(0), tcp_wxyz(1), tcp_wxyz(2), tcp_wxyz(3));
   tcp.linear() = q.matrix();
@@ -480,16 +471,14 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
   input_pose.linear() = q.matrix();
   input_pose.translation() = xyz;
 
-  VectorOfVectorPtr f(new CartPoseErrCalculator(input_pose, prob.GetKin(), prob.GetEnv(), link, tcp));
+  sco::VectorOfVectorPtr f(new CartPoseErrCalculator(input_pose, prob.GetKin(), prob.GetEnv(), link, tcp));
   if (term_type == TT_COST)
   {
-    prob.addCost(
-        CostPtr(new TrajOptCostFromErrFunc(f, prob.GetVarRow(timestep), concat(rot_coeffs, pos_coeffs), ABS, name)));
+    prob.addCost(sco::CostPtr(new TrajOptCostFromErrFunc(f, prob.GetVarRow(timestep), concat(rot_coeffs, pos_coeffs), sco::ABS, name)));
   }
   else if (term_type == TT_CNT)
   {
-    prob.addConstraint(ConstraintPtr(
-        new TrajOptConstraintFromErrFunc(f, prob.GetVarRow(timestep), concat(rot_coeffs, pos_coeffs), EQ, name)));
+    prob.addConstraint(sco::ConstraintPtr(new TrajOptConstraintFromErrFunc(f, prob.GetVarRow(timestep), concat(rot_coeffs, pos_coeffs), sco::EQ, name)));
   }
   else
   {
@@ -497,18 +486,18 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
   }
 }
 
-void CartVelTermInfo::fromJson(ProblemConstructionInfo& pci, const Value& v)
+void CartVelTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value& v)
 {
   FAIL_IF_FALSE(v.isMember("params"));
-  const Value& params = v["params"];
-  childFromJson(params, first_step, "first_step");
-  childFromJson(params, last_step, "last_step");
-  childFromJson(params, max_displacement, "max_displacement");
+  const Json::Value& params = v["params"];
+  json_marshal::childFromJson(params, first_step, "first_step");
+  json_marshal::childFromJson(params, last_step, "last_step");
+  json_marshal::childFromJson(params, max_displacement, "max_displacement");
 
   FAIL_IF_FALSE((first_step >= 0) && (first_step <= pci.basic_info.n_steps - 1) && (first_step < last_step));
   FAIL_IF_FALSE((last_step > 0) && (last_step <= pci.basic_info.n_steps - 1));
 
-  childFromJson(params, link, "link");
+  json_marshal::childFromJson(params, link, "link");
   const std::vector<std::string>& link_names = pci.kin->getLinkNames();
   if (std::find(link_names.begin(), link_names.end(), link) == link_names.end())
   {
@@ -525,12 +514,12 @@ void CartVelTermInfo::hatch(TrajOptProb& prob)
   {
     for (int iStep = first_step; iStep < last_step; ++iStep)
     {
-      prob.addCost(CostPtr(new TrajOptCostFromErrFunc(
-          VectorOfVectorPtr(new CartVelErrCalculator(prob.GetKin(), prob.GetEnv(), link, max_displacement)),
-          MatrixOfVectorPtr(new CartVelJacCalculator(prob.GetKin(), prob.GetEnv(), link, max_displacement)),
+      prob.addCost(sco::CostPtr(new TrajOptCostFromErrFunc(
+          sco::VectorOfVectorPtr(new CartVelErrCalculator(prob.GetKin(), prob.GetEnv(), link, max_displacement)),
+          sco::MatrixOfVectorPtr(new CartVelJacCalculator(prob.GetKin(), prob.GetEnv(), link, max_displacement)),
           concat(prob.GetVarRow(iStep), prob.GetVarRow(iStep + 1)),
-          VectorXd::Ones(0),
-          ABS,
+          Eigen::VectorXd::Ones(0),
+          sco::ABS,
           name)));
     }
   }
@@ -538,12 +527,12 @@ void CartVelTermInfo::hatch(TrajOptProb& prob)
   {
     for (int iStep = first_step; iStep < last_step; ++iStep)
     {
-      prob.addConstraint(ConstraintPtr(new TrajOptConstraintFromErrFunc(
-          VectorOfVectorPtr(new CartVelErrCalculator(prob.GetKin(), prob.GetEnv(), link, max_displacement)),
-          MatrixOfVectorPtr(new CartVelJacCalculator(prob.GetKin(), prob.GetEnv(), link, max_displacement)),
+      prob.addConstraint(sco::ConstraintPtr(new TrajOptConstraintFromErrFunc(
+          sco::VectorOfVectorPtr(new CartVelErrCalculator(prob.GetKin(), prob.GetEnv(), link, max_displacement)),
+          sco::MatrixOfVectorPtr(new CartVelJacCalculator(prob.GetKin(), prob.GetEnv(), link, max_displacement)),
           concat(prob.GetVarRow(iStep), prob.GetVarRow(iStep + 1)),
-          VectorXd::Ones(0),
-          INEQ,
+          Eigen::VectorXd::Ones(0),
+          sco::INEQ,
           "CartVel")));
     }
   }
@@ -553,13 +542,13 @@ void CartVelTermInfo::hatch(TrajOptProb& prob)
   }
 }
 
-void JointPosTermInfo::fromJson(ProblemConstructionInfo& pci, const Value& v)
+void JointPosTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value& v)
 {
   FAIL_IF_FALSE(v.isMember("params"));
   int n_steps = pci.basic_info.n_steps;
-  const Value& params = v["params"];
-  childFromJson(params, vals, "vals");
-  childFromJson(params, coeffs, "coeffs");
+  const Json::Value& params = v["params"];
+  json_marshal::childFromJson(params, vals, "vals");
+  json_marshal::childFromJson(params, coeffs, "coeffs");
   if (coeffs.size() == 1)
     coeffs = DblVec(n_steps, coeffs[0]);
   unsigned n_dof = pci.kin->numJoints();
@@ -567,7 +556,7 @@ void JointPosTermInfo::fromJson(ProblemConstructionInfo& pci, const Value& v)
   {
     PRINT_AND_THROW(boost::format("wrong number of dof vals. expected %i got %i") % n_dof % vals.size());
   }
-  childFromJson(params, timestep, "timestep", pci.basic_info.n_steps - 1);
+  json_marshal::childFromJson(params, timestep, "timestep", pci.basic_info.n_steps - 1);
 
   const char* all_fields[] = { "vals", "coeffs", "timestep" };
   ensure_only_members(params, all_fields, sizeof(all_fields) / sizeof(char*));
@@ -577,16 +566,16 @@ void JointPosTermInfo::hatch(TrajOptProb& prob)
 {
   if (term_type == TT_COST)
   {
-    prob.addCost(CostPtr(new JointPosCost(prob.GetVarRow(timestep), toVectorXd(vals), toVectorXd(coeffs))));
+    prob.addCost(sco::CostPtr(new JointPosCost(prob.GetVarRow(timestep), util::toVectorXd(vals), util::toVectorXd(coeffs))));
     prob.getCosts().back()->setName(name);
   }
   else if (term_type == TT_CNT)
   {
-    VarVector vars = prob.GetVarRow(timestep);
+    sco::VarVector vars = prob.GetVarRow(timestep);
     int n_dof = vars.size();
     for (int j = 0; j < n_dof; ++j)
     {
-      prob.addLinearConstraint(exprSub(AffExpr(vars[j]), vals[j]), EQ);
+      prob.addLinearConstraint(sco::exprSub(sco::AffExpr(vars[j]), vals[j]), sco::EQ);
     }
   }
   else
@@ -595,14 +584,14 @@ void JointPosTermInfo::hatch(TrajOptProb& prob)
   }
 }
 
-void JointVelTermInfo::fromJson(ProblemConstructionInfo& pci, const Value& v)
+void JointVelTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value& v)
 {
   FAIL_IF_FALSE(v.isMember("params"));
-  const Value& params = v["params"];
+  const Json::Value& params = v["params"];
 
-  childFromJson(params, coeffs, "coeffs");
-  childFromJson(params, first_step, "first_step", 0);
-  childFromJson(params, last_step, "last_step", pci.basic_info.n_steps - 1);
+  json_marshal::childFromJson(params, coeffs, "coeffs");
+  json_marshal::childFromJson(params, first_step, "first_step", 0);
+  json_marshal::childFromJson(params, last_step, "last_step", pci.basic_info.n_steps - 1);
   unsigned n_dof = pci.kin->numJoints();
   if (coeffs.size() == 1)
   {
@@ -622,7 +611,7 @@ void JointVelTermInfo::hatch(TrajOptProb& prob)
 {
   if (term_type == TT_COST)
   {
-    prob.addCost(CostPtr(new JointVelCost(prob.GetVars(), toVectorXd(coeffs))));
+    prob.addCost(sco::CostPtr(new JointVelCost(prob.GetVars(), util::toVectorXd(coeffs))));
     prob.getCosts().back()->setName(name);
   }
   else if (term_type == TT_CNT)
@@ -632,9 +621,9 @@ void JointVelTermInfo::hatch(TrajOptProb& prob)
     {
       for (std::size_t j = 0; j < coeffs.size(); ++j)
       {
-        AffExpr vel = prob.GetVar(i + 1, j) - prob.GetVar(i, j);
-        prob.addLinearConstraint(vel - coeffs[j], INEQ);
-        prob.addLinearConstraint(-vel - coeffs[j], INEQ);
+        sco::AffExpr vel = prob.GetVar(i + 1, j) - prob.GetVar(i, j);
+        prob.addLinearConstraint(vel - coeffs[j], sco::INEQ);
+        prob.addLinearConstraint(-vel - coeffs[j], sco::INEQ);
       }
     }
   }
@@ -644,12 +633,12 @@ void JointVelTermInfo::hatch(TrajOptProb& prob)
   }
 }
 
-void JointAccTermInfo::fromJson(ProblemConstructionInfo& pci, const Value& v)
+void JointAccTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value& v)
 {
   FAIL_IF_FALSE(v.isMember("params"));
-  const Value& params = v["params"];
+  const Json::Value& params = v["params"];
 
-  childFromJson(params, coeffs, "coeffs");
+  json_marshal::childFromJson(params, coeffs, "coeffs");
   unsigned n_dof = pci.kin->numJoints();
   if (coeffs.size() == 1)
     coeffs = DblVec(n_dof, coeffs[0]);
@@ -666,7 +655,7 @@ void JointAccTermInfo::hatch(TrajOptProb& prob)
 {
   if (term_type == TT_COST)
   {
-    prob.addCost(CostPtr(new JointAccCost(prob.GetVars(), toVectorXd(coeffs))));
+    prob.addCost(sco::CostPtr(new JointAccCost(prob.GetVars(), util::toVectorXd(coeffs))));
     prob.getCosts().back()->setName(name);
   }
   else if (term_type == TT_CNT)
@@ -676,9 +665,9 @@ void JointAccTermInfo::hatch(TrajOptProb& prob)
     {
       for (std::size_t j = 0; j < coeffs.size(); ++j)
       {
-        AffExpr acc = prob.GetVar(i + 1, j) - 2 * prob.GetVar(i, j) + prob.GetVar(i - 1, j);
-        prob.addLinearConstraint(acc - coeffs[j], INEQ);
-        prob.addLinearConstraint(-acc - coeffs[j], INEQ);
+        sco::AffExpr acc = prob.GetVar(i + 1, j) - 2 * prob.GetVar(i, j) + prob.GetVar(i - 1, j);
+        prob.addLinearConstraint(acc - coeffs[j], sco::INEQ);
+        prob.addLinearConstraint(-acc - coeffs[j], sco::INEQ);
       }
     }
   }
@@ -688,12 +677,12 @@ void JointAccTermInfo::hatch(TrajOptProb& prob)
   }
 }
 
-void JointJerkTermInfo::fromJson(ProblemConstructionInfo& pci, const Value& v)
+void JointJerkTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value& v)
 {
   FAIL_IF_FALSE(v.isMember("params"));
-  const Value& params = v["params"];
+  const Json::Value& params = v["params"];
 
-  childFromJson(params, coeffs, "coeffs");
+  json_marshal::childFromJson(params, coeffs, "coeffs");
   unsigned n_dof = pci.kin->numJoints();
   if (coeffs.size() == 1)
     coeffs = DblVec(n_dof, coeffs[0]);
@@ -710,7 +699,7 @@ void JointJerkTermInfo::hatch(TrajOptProb& prob)
 {
   if (term_type == TT_COST)
   {
-    prob.addCost(CostPtr(new JointJerkCost(prob.GetVars(), toVectorXd(coeffs))));
+    prob.addCost(sco::CostPtr(new JointJerkCost(prob.GetVars(), util::toVectorXd(coeffs))));
     prob.getCosts().back()->setName(name);
   }
   else if (term_type == TT_CNT)
@@ -720,10 +709,10 @@ void JointJerkTermInfo::hatch(TrajOptProb& prob)
     {
       for (std::size_t j = 0; j < coeffs.size(); ++j)
       {
-        AffExpr jerk =
+        sco::AffExpr jerk =
             prob.GetVar(i + 2, j) - 3 * prob.GetVar(i + 1, j) + 3 * prob.GetVar(i, j) - prob.GetVar(i - 1, j);
-        prob.addLinearConstraint(jerk - coeffs[j], INEQ);
-        prob.addLinearConstraint(-jerk - coeffs[j], INEQ);
+        prob.addLinearConstraint(jerk - coeffs[j], sco::INEQ);
+        prob.addLinearConstraint(-jerk - coeffs[j], sco::INEQ);
       }
     }
   }
@@ -733,22 +722,22 @@ void JointJerkTermInfo::hatch(TrajOptProb& prob)
   }
 }
 
-void CollisionTermInfo::fromJson(ProblemConstructionInfo& pci, const Value& v)
+void CollisionTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value& v)
 {
   FAIL_IF_FALSE(v.isMember("params"));
-  const Value& params = v["params"];
+  const Json::Value& params = v["params"];
 
   int n_steps = pci.basic_info.n_steps;
-  childFromJson(params, continuous, "continuous", true);
-  childFromJson(params, first_step, "first_step", 0);
-  childFromJson(params, last_step, "last_step", n_steps - 1);
-  childFromJson(params, gap, "gap", 1);
+  json_marshal::childFromJson(params, continuous, "continuous", true);
+  json_marshal::childFromJson(params, first_step, "first_step", 0);
+  json_marshal::childFromJson(params, last_step, "last_step", n_steps - 1);
+  json_marshal::childFromJson(params, gap, "gap", 1);
   FAIL_IF_FALSE(gap >= 0);
   FAIL_IF_FALSE((first_step >= 0) && (first_step < n_steps));
   FAIL_IF_FALSE((last_step >= first_step) && (last_step < n_steps));
 
   DblVec coeffs, dist_pen;
-  childFromJson(params, coeffs, "coeffs");
+  json_marshal::childFromJson(params, coeffs, "coeffs");
   int n_terms = last_step - first_step + 1;
   if (coeffs.size() == 1)
     coeffs = DblVec(n_terms, coeffs[0]);
@@ -756,7 +745,7 @@ void CollisionTermInfo::fromJson(ProblemConstructionInfo& pci, const Value& v)
   {
     PRINT_AND_THROW(boost::format("wrong size: coeffs. expected %i got %i") % n_terms % coeffs.size());
   }
-  childFromJson(params, dist_pen, "dist_pen");
+  json_marshal::childFromJson(params, dist_pen, "dist_pen");
   if (dist_pen.size() == 1)
     dist_pen = DblVec(n_terms, dist_pen[0]);
   else if (static_cast<int>(dist_pen.size()) != n_terms)
@@ -775,16 +764,16 @@ void CollisionTermInfo::fromJson(ProblemConstructionInfo& pci, const Value& v)
   // Check if data was set for individual pairs
   if (params.isMember("pairs"))
   {
-    const Value& pairs = params["pairs"];
+    const Json::Value& pairs = params["pairs"];
     for (Json::Value::const_iterator it = pairs.begin(); it != pairs.end(); ++it)
     {
       FAIL_IF_FALSE(it->isMember("link"));
       std::string link;
-      childFromJson(*it, link, "link");
+      json_marshal::childFromJson(*it, link, "link");
 
       FAIL_IF_FALSE(it->isMember("pair"));
       std::vector<std::string> pair;
-      childFromJson(*it, pair, "pair");
+      json_marshal::childFromJson(*it, pair, "pair");
 
       if (pair.size() == 0)
       {
@@ -792,7 +781,7 @@ void CollisionTermInfo::fromJson(ProblemConstructionInfo& pci, const Value& v)
       }
 
       DblVec pair_coeffs;
-      childFromJson(*it, pair_coeffs, "coeffs");
+      json_marshal::childFromJson(*it, pair_coeffs, "coeffs");
       if (pair_coeffs.size() == 1)
       {
         pair_coeffs = DblVec(n_terms, pair_coeffs[0]);
@@ -803,7 +792,7 @@ void CollisionTermInfo::fromJson(ProblemConstructionInfo& pci, const Value& v)
       }
 
       DblVec pair_dist_pen;
-      childFromJson(*it, pair_dist_pen, "dist_pen");
+      json_marshal::childFromJson(*it, pair_dist_pen, "dist_pen");
       if (pair_dist_pen.size() == 1)
       {
         pair_dist_pen = DblVec(n_terms, pair_dist_pen[0]);
@@ -837,7 +826,7 @@ void CollisionTermInfo::hatch(TrajOptProb& prob)
     {
       for (int i = first_step; i <= last_step - gap; ++i)
       {
-        prob.addCost(CostPtr(new CollisionCost(
+        prob.addCost(sco::CostPtr(new CollisionCost(
             prob.GetKin(), prob.GetEnv(), info[i - first_step], prob.GetVarRow(i), prob.GetVarRow(i + gap))));
         prob.getCosts().back()->setName((boost::format("%s_%i") % name % i).str());
       }
@@ -846,7 +835,7 @@ void CollisionTermInfo::hatch(TrajOptProb& prob)
     {
       for (int i = first_step; i <= last_step; ++i)
       {
-        prob.addCost(CostPtr(new CollisionCost(prob.GetKin(), prob.GetEnv(), info[i - first_step], prob.GetVarRow(i))));
+        prob.addCost(sco::CostPtr(new CollisionCost(prob.GetKin(), prob.GetEnv(), info[i - first_step], prob.GetVarRow(i))));
         prob.getCosts().back()->setName((boost::format("%s_%i") % name % i).str());
       }
     }
@@ -857,7 +846,7 @@ void CollisionTermInfo::hatch(TrajOptProb& prob)
     {
       for (int i = first_step; i < last_step; ++i)
       {
-        prob.addIneqConstraint(ConstraintPtr(new CollisionConstraint(
+        prob.addIneqConstraint(sco::ConstraintPtr(new CollisionConstraint(
             prob.GetKin(), prob.GetEnv(), info[i - first_step], prob.GetVarRow(i), prob.GetVarRow(i + 1))));
         prob.getIneqConstraints().back()->setName((boost::format("%s_%i") % name % i).str());
       }
@@ -866,7 +855,7 @@ void CollisionTermInfo::hatch(TrajOptProb& prob)
     {
       for (int i = first_step; i <= last_step; ++i)
       {
-        prob.addIneqConstraint(ConstraintPtr(
+        prob.addIneqConstraint(sco::ConstraintPtr(
             new CollisionConstraint(prob.GetKin(), prob.GetEnv(), info[i - first_step], prob.GetVarRow(i))));
         prob.getIneqConstraints().back()->setName((boost::format("%s_%i") % name % i).str());
       }

--- a/trajopt/src/trajectory_costs.cpp
+++ b/trajopt/src/trajectory_costs.cpp
@@ -3,13 +3,9 @@
 #include <trajopt_sco/expr_ops.hpp>
 #include <trajopt_sco/modeling_utils.hpp>
 
-using namespace std;
-using namespace sco;
-using namespace Eigen;
-
 namespace
 {
-static MatrixXd diffAxis0(const MatrixXd& in)
+static Eigen::MatrixXd diffAxis0(const Eigen::MatrixXd& in)
 {
   return in.middleRows(1, in.rows() - 1) - in.middleRows(0, in.rows() - 1);
 }
@@ -19,108 +15,108 @@ namespace trajopt
 {
 //////////// Quadratic cost functions /////////////////
 
-JointPosCost::JointPosCost(const VarVector& vars, const VectorXd& vals, const VectorXd& coeffs)
+JointPosCost::JointPosCost(const sco::VarVector& vars, const Eigen::VectorXd& vals, const Eigen::VectorXd& coeffs)
   : Cost("JointPos"), vars_(vars), vals_(vals), coeffs_(coeffs)
 {
   for (std::size_t i = 0; i < vars.size(); ++i)
   {
     if (coeffs[i] > 0)
     {
-      AffExpr diff = exprSub(AffExpr(vars[i]), AffExpr(vals[i]));
-      exprInc(expr_, exprMult(exprSquare(diff), coeffs[i]));
+      sco::AffExpr diff = sco::exprSub(sco::AffExpr(vars[i]), sco::AffExpr(vals[i]));
+      sco::exprInc(expr_, sco::exprMult(sco::exprSquare(diff), coeffs[i]));
     }
   }
 }
-double JointPosCost::value(const vector<double>& xvec)
+double JointPosCost::value(const DblVec& xvec)
 {
-  VectorXd dofs = getVec(xvec, vars_);
+  Eigen::VectorXd dofs = sco::getVec(xvec, vars_);
   return ((dofs - vals_).array().square() * coeffs_.array()).sum();
 }
-ConvexObjectivePtr JointPosCost::convex(const vector<double>& /*x*/, Model* model)
+sco::ConvexObjectivePtr JointPosCost::convex(const DblVec& /*x*/, sco::Model* model)
 {
-  ConvexObjectivePtr out(new ConvexObjective(model));
+  sco::ConvexObjectivePtr out(new sco::ConvexObjective(model));
   out->addQuadExpr(expr_);
   return out;
 }
 
-JointVelCost::JointVelCost(const VarArray& vars, const VectorXd& coeffs)
+JointVelCost::JointVelCost(const VarArray& vars, const Eigen::VectorXd& coeffs)
   : Cost("JointVel"), vars_(vars), coeffs_(coeffs)
 {
   for (int i = 0; i < vars.rows() - 1; ++i)
   {
     for (int j = 0; j < vars.cols(); ++j)
     {
-      AffExpr vel;
-      exprInc(vel, exprMult(vars(i, j), -1));
-      exprInc(vel, exprMult(vars(i + 1, j), 1));
-      exprInc(expr_, exprMult(exprSquare(vel), coeffs_[j]));
+      sco::AffExpr vel;
+      sco::exprInc(vel, sco::exprMult(vars(i, j), -1));
+      sco::exprInc(vel, sco::exprMult(vars(i + 1, j), 1));
+      sco::exprInc(expr_, sco::exprMult(sco::exprSquare(vel), coeffs_[j]));
     }
   }
 }
-double JointVelCost::value(const vector<double>& xvec)
+double JointVelCost::value(const DblVec& xvec)
 {
-  MatrixXd traj = getTraj(xvec, vars_);
+  Eigen::MatrixXd traj = getTraj(xvec, vars_);
   return (diffAxis0(traj).array().square().matrix() * coeffs_.asDiagonal()).sum();
 }
-ConvexObjectivePtr JointVelCost::convex(const vector<double>& /*x*/, Model* model)
+sco::ConvexObjectivePtr JointVelCost::convex(const DblVec& /*x*/, sco::Model* model)
 {
-  ConvexObjectivePtr out(new ConvexObjective(model));
+  sco::ConvexObjectivePtr out(new sco::ConvexObjective(model));
   out->addQuadExpr(expr_);
   return out;
 }
 
-JointAccCost::JointAccCost(const VarArray& vars, const VectorXd& coeffs)
+JointAccCost::JointAccCost(const VarArray& vars, const Eigen::VectorXd& coeffs)
   : Cost("JointAcc"), vars_(vars), coeffs_(coeffs)
 {
   for (int i = 0; i < vars.rows() - 2; ++i)
   {
     for (int j = 0; j < vars.cols(); ++j)
     {
-      AffExpr acc;
-      exprInc(acc, exprMult(vars(i, j), 1.0));
-      exprInc(acc, exprMult(vars(i + 1, j), -2.0));
-      exprInc(acc, exprMult(vars(i + 2, j), 1.0));
-      exprInc(expr_, exprMult(exprSquare(acc), coeffs_[j]));
+      sco::AffExpr acc;
+      sco::exprInc(acc, sco::exprMult(vars(i, j), 1.0));
+      sco::exprInc(acc, sco::exprMult(vars(i + 1, j), -2.0));
+      sco::exprInc(acc, sco::exprMult(vars(i + 2, j), 1.0));
+      sco::exprInc(expr_, sco::exprMult(sco::exprSquare(acc), coeffs_[j]));
     }
   }
 }
-double JointAccCost::value(const vector<double>& xvec)
+double JointAccCost::value(const DblVec& xvec)
 {
-  MatrixXd traj = getTraj(xvec, vars_);
+  Eigen::MatrixXd traj = getTraj(xvec, vars_);
   return (diffAxis0(diffAxis0(traj)).array().square().matrix() * coeffs_.asDiagonal()).sum();
 }
-ConvexObjectivePtr JointAccCost::convex(const vector<double>& /*x*/, Model* model)
+sco::ConvexObjectivePtr JointAccCost::convex(const DblVec& /*x*/, sco::Model* model)
 {
-  ConvexObjectivePtr out(new ConvexObjective(model));
+  sco::ConvexObjectivePtr out(new sco::ConvexObjective(model));
   out->addQuadExpr(expr_);
   return out;
 }
 
-JointJerkCost::JointJerkCost(const VarArray& vars, const VectorXd& coeffs)
+JointJerkCost::JointJerkCost(const VarArray& vars, const Eigen::VectorXd& coeffs)
   : Cost("JointJerk"), vars_(vars), coeffs_(coeffs)
 {
   for (int i = 0; i < vars.rows() - 4; ++i)
   {
     for (int j = 0; j < vars.cols(); ++j)
     {
-      AffExpr acc;
-      exprInc(acc, exprMult(vars(i, j), -1.0 / 2.0));
-      exprInc(acc, exprMult(vars(i + 1, j), 1.0));
-      exprInc(acc, exprMult(vars(i + 2, j), 0.0));
-      exprInc(acc, exprMult(vars(i + 3, j), -1.0));
-      exprInc(acc, exprMult(vars(i + 4, j), 1.0 / 2.0));
-      exprInc(expr_, exprMult(exprSquare(acc), coeffs_[j]));
+      sco::AffExpr acc;
+      sco::exprInc(acc, sco::exprMult(vars(i, j), -1.0 / 2.0));
+      sco::exprInc(acc, sco::exprMult(vars(i + 1, j), 1.0));
+      sco::exprInc(acc, sco::exprMult(vars(i + 2, j), 0.0));
+      sco::exprInc(acc, sco::exprMult(vars(i + 3, j), -1.0));
+      sco::exprInc(acc, sco::exprMult(vars(i + 4, j), 1.0 / 2.0));
+      sco::exprInc(expr_, sco::exprMult(sco::exprSquare(acc), coeffs_[j]));
     }
   }
 }
-double JointJerkCost::value(const vector<double>& xvec)
+double JointJerkCost::value(const DblVec& xvec)
 {
-  MatrixXd traj = getTraj(xvec, vars_);
+  Eigen::MatrixXd traj = getTraj(xvec, vars_);
   return (diffAxis0(diffAxis0(diffAxis0(traj))).array().square().matrix() * coeffs_.asDiagonal()).sum();
 }
-ConvexObjectivePtr JointJerkCost::convex(const vector<double>& /*x*/, Model* model)
+sco::ConvexObjectivePtr JointJerkCost::convex(const DblVec& /*x*/, sco::Model* model)
 {
-  ConvexObjectivePtr out(new ConvexObjective(model));
+  sco::ConvexObjectivePtr out(new sco::ConvexObjective(model));
   out->addQuadExpr(expr_);
   return out;
 }

--- a/trajopt/src/utils.cpp
+++ b/trajopt/src/utils.cpp
@@ -3,8 +3,6 @@
 #include <trajopt/utils.hpp>
 #include <trajopt_sco/solver_interface.hpp>
 
-using namespace Eigen;
-
 namespace trajopt
 {
 TrajArray getTraj(const DblVec& x, const VarArray& vars)
@@ -22,7 +20,7 @@ TrajArray getTraj(const DblVec& x, const VarArray& vars)
 
 TrajArray getTraj(const DblVec& x, const AffArray& arr)
 {
-  MatrixXd out(arr.rows(), arr.cols());
+  Eigen::MatrixXd out(arr.rows(), arr.cols());
   for (int i = 0; i < arr.rows(); ++i)
   {
     for (int j = 0; j < arr.cols(); ++j)
@@ -33,23 +31,23 @@ TrajArray getTraj(const DblVec& x, const AffArray& arr)
   return out;
 }
 
-void AddVarArrays(OptProb& prob,
+void AddVarArrays(sco::OptProb& prob,
                   int rows,
-                  const vector<int>& cols,
-                  const vector<string>& name_prefix,
-                  const vector<VarArray*>& newvars)
+                  const IntVec& cols,
+                  const std::vector<std::string>& name_prefix,
+                  const std::vector<VarArray*>& newvars)
 {
   int n_arr = name_prefix.size();
   assert(static_cast<unsigned>(n_arr) == newvars.size());
 
-  vector<MatrixXi> index(n_arr);
+  std::vector<Eigen::MatrixXi> index(n_arr);
   for (int i = 0; i < n_arr; ++i)
   {
     newvars[i]->resize(rows, cols[i]);
     index[i].resize(rows, cols[i]);
   }
 
-  vector<string> names;
+  std::vector<std::string> names;
   int var_idx = prob.getNumVars();
   for (int i = 0; i < rows; ++i)
   {
@@ -65,7 +63,7 @@ void AddVarArrays(OptProb& prob,
   }
   prob.createVariables(names);  // note that w,r, are both unbounded
 
-  const vector<Var>& vars = prob.getVars();
+  const std::vector<sco::Var>& vars = prob.getVars();
   for (int k = 0; k < n_arr; ++k)
   {
     for (int i = 0; i < rows; ++i)
@@ -78,11 +76,11 @@ void AddVarArrays(OptProb& prob,
   }
 }
 
-void AddVarArray(OptProb& prob, int rows, int cols, const string& name_prefix, VarArray& newvars)
+void AddVarArray(sco::OptProb& prob, int rows, int cols, const std::string& name_prefix, VarArray& newvars)
 {
-  vector<VarArray*> arrs(1, &newvars);
-  vector<string> prefixes(1, name_prefix);
-  vector<int> colss(1, cols);
+  std::vector<VarArray*> arrs(1, &newvars);
+  std::vector<std::string> prefixes(1, name_prefix);
+  std::vector<int> colss(1, cols);
   AddVarArrays(prob, rows, colss, prefixes, arrs);
 }
 }

--- a/trajopt/test/cast_cost_attached_unit.cpp
+++ b/trajopt/test/cast_cost_attached_unit.cpp
@@ -137,7 +137,7 @@ TEST_F(CastAttachedTest, LinkWithGeom)
   EXPECT_TRUE(found);
   ROS_INFO((found) ? ("Initial trajectory is in collision") : ("Initial trajectory is collision free"));
 
-  BasicTrustRegionSQP opt(prob);
+  sco::BasicTrustRegionSQP opt(prob);
   if (plotting)
     opt.addCallback(PlotCallback(*prob, plotter_));
   opt.initialize(trajToDblVec(prob->GetInitTraj()));
@@ -188,7 +188,7 @@ TEST_F(CastAttachedTest, LinkWithoutGeom)
   EXPECT_TRUE(found);
   ROS_INFO((found) ? ("Initial trajectory is in collision") : ("Initial trajectory is collision free"));
 
-  BasicTrustRegionSQP opt(prob);
+  sco::BasicTrustRegionSQP opt(prob);
   if (plotting)
     opt.addCallback(PlotCallback(*prob, plotter_));
   opt.initialize(trajToDblVec(prob->GetInitTraj()));

--- a/trajopt/test/cast_cost_octomap_unit.cpp
+++ b/trajopt/test/cast_cost_octomap_unit.cpp
@@ -137,7 +137,7 @@ TEST_F(CastOctomapTest, boxes)
   EXPECT_TRUE(found);
   ROS_INFO((found) ? ("Initial trajectory is in collision") : ("Initial trajectory is collision free"));
 
-  BasicTrustRegionSQP opt(prob);
+  sco::BasicTrustRegionSQP opt(prob);
   if (plotting)
     opt.addCallback(PlotCallback(*prob, plotter_));
   opt.initialize(trajToDblVec(prob->GetInitTraj()));

--- a/trajopt/test/cast_cost_unit.cpp
+++ b/trajopt/test/cast_cost_unit.cpp
@@ -92,7 +92,7 @@ TEST_F(CastTest, boxes)
   EXPECT_TRUE(found);
   ROS_INFO((found) ? ("Initial trajectory is in collision") : ("Initial trajectory is collision free"));
 
-  BasicTrustRegionSQP opt(prob);
+  sco::BasicTrustRegionSQP opt(prob);
   if (plotting)
     opt.addCallback(PlotCallback(*prob, plotter_));
   opt.initialize(trajToDblVec(prob->GetInitTraj()));

--- a/trajopt/test/cast_cost_world_unit.cpp
+++ b/trajopt/test/cast_cost_world_unit.cpp
@@ -120,7 +120,7 @@ TEST_F(CastWorldTest, boxes)
   EXPECT_TRUE(found);
   ROS_INFO((found) ? ("Initial trajectory is in collision") : ("Initial trajectory is collision free"));
 
-  BasicTrustRegionSQP opt(prob);
+  sco::BasicTrustRegionSQP opt(prob);
   if (plotting)
     opt.addCallback(PlotCallback(*prob, plotter_));
   opt.initialize(trajToDblVec(prob->GetInitTraj()));

--- a/trajopt/test/planning_unit.cpp
+++ b/trajopt/test/planning_unit.cpp
@@ -77,7 +77,7 @@ TEST_F(PlanningTest, numerical_ik1)
   TrajOptProbPtr prob = ConstructProblem(root, env_);
   ASSERT_TRUE(!!prob);
 
-  BasicTrustRegionSQP opt(prob);
+  sco::BasicTrustRegionSQP opt(prob);
   if (plotting)
   {
     opt.addCallback(PlotCallback(*prob, plotter_));
@@ -93,7 +93,7 @@ TEST_F(PlanningTest, numerical_ik1)
   prob->GetKin()->calcFwdKin(initial_pose, change_base, toVectorXd(opt.x()));
 
   ROS_DEBUG_STREAM("Initial Position: " << initial_pose.translation().transpose());
-  OptStatus status = opt.optimize();
+  sco::OptStatus status = opt.optimize();
   ROS_DEBUG_STREAM("Status: " << sco::statusToString(status));
   prob->GetKin()->calcFwdKin(final_pose, change_base, toVectorXd(opt.x()));
 
@@ -149,7 +149,7 @@ TEST_F(PlanningTest, arm_around_table)
   EXPECT_TRUE(found);
   ROS_INFO((found) ? ("Initial trajectory is in collision") : ("Initial trajectory is collision free"));
 
-  BasicTrustRegionSQP opt(prob);
+  sco::BasicTrustRegionSQP opt(prob);
   ROS_DEBUG_STREAM("DOF: " << prob->GetNumDOF());
   if (plotting)
   {

--- a/trajopt_examples/src/basic_cartesian_plan.cpp
+++ b/trajopt_examples/src/basic_cartesian_plan.cpp
@@ -210,7 +210,7 @@ int main(int argc, char** argv)
   plotter->plotScene();
 
   // Set Log Level
-  gLogLevel = util::LevelInfo;
+  util::gLogLevel = util::LevelInfo;
 
   // Setup Problem
   TrajOptProbPtr prob;
@@ -232,7 +232,7 @@ int main(int argc, char** argv)
 
   ROS_INFO((found) ? ("Final trajectory is in collision") : ("Final trajectory is collision free"));
 
-  BasicTrustRegionSQP opt(prob);
+  sco::BasicTrustRegionSQP opt(prob);
   if (plotting_)
   {
     opt.addCallback(PlotCallback(*prob, plotter));

--- a/trajopt_examples/src/car_seat_demo.cpp
+++ b/trajopt_examples/src/car_seat_demo.cpp
@@ -57,8 +57,7 @@ void addSeats()
     AttachedBodyInfo attached_body;
     attached_body.object_name = "seat_" + std::to_string(i + 1);
     attached_body.parent_link_name = "world";
-    attached_body.transform = Eigen::AngleAxisd(0.0, Vector3d::UnitX()) * Eigen::AngleAxisd(0.0, Vector3d::UnitY()) *
-                              Eigen::AngleAxisd(3.14159, Vector3d::UnitZ());
+    attached_body.transform = Eigen::AngleAxisd(0.0, Eigen::Vector3d::UnitX()) * Eigen::AngleAxisd(0.0, Eigen::Vector3d::UnitY()) * Eigen::AngleAxisd(3.14159, Eigen::Vector3d::UnitZ());
     attached_body.transform.translation() = Eigen::Vector3d(0.5 + i, 2.15, 0.45);
 
     env_->attachBody(attached_body);
@@ -211,7 +210,7 @@ std::shared_ptr<ProblemConstructionInfo> cppMethod(const std::string& start, con
   pci->init_info.type = InitInfo::GIVEN_TRAJ;
   pci->init_info.data = start_pos.transpose().replicate(pci->basic_info.n_steps, 1);
   for (auto i = 0; i < start_pos.size(); ++i)
-    pci->init_info.data.col(i) = VectorXd::LinSpaced(pci->basic_info.n_steps, start_pos[i], joint_pose[i]);
+    pci->init_info.data.col(i) = Eigen::VectorXd::LinSpaced(pci->basic_info.n_steps, start_pos[i], joint_pose[i]);
 
   // Populate Cost Info
   std::shared_ptr<JointVelTermInfo> joint_vel = std::shared_ptr<JointVelTermInfo>(new JointVelTermInfo);
@@ -297,7 +296,7 @@ int main(int argc, char** argv)
   plotter->plotScene();
 
   // Set Log Level
-  gLogLevel = util::LevelInfo;
+  util::gLogLevel = util::LevelInfo;
 
   // Solve Trajectory
   ROS_INFO("Car Seat Demo Started");
@@ -309,7 +308,7 @@ int main(int argc, char** argv)
 
   pci = cppMethod("Home", "Pick1");
   prob = ConstructProblem(*pci);
-  BasicTrustRegionSQP pick1_opt(prob);
+  sco::BasicTrustRegionSQP pick1_opt(prob);
   if (plotting_)
     pick1_opt.addCallback(PlotCallback(*prob, plotter));
 
@@ -350,7 +349,7 @@ int main(int argc, char** argv)
 
   pci = cppMethod("Pick1", "Place1");
   prob = ConstructProblem(*pci);
-  BasicTrustRegionSQP place1_opt(prob);
+  sco::BasicTrustRegionSQP place1_opt(prob);
   if (plotting_)
     place1_opt.addCallback(PlotCallback(*prob, plotter));
 

--- a/trajopt_examples/src/glass_up_right_plan.cpp
+++ b/trajopt_examples/src/glass_up_right_plan.cpp
@@ -93,7 +93,7 @@ TrajOptProbPtr cppMethod()
   pci.init_info.data = TrajArray(steps_, pci.kin->numJoints());
   for (unsigned idof = 0; idof < pci.kin->numJoints(); ++idof)
   {
-    pci.init_info.data.col(idof) = VectorXd::LinSpaced(steps_, start_pos[idof], end_pos[idof]);
+    pci.init_info.data.col(idof) = Eigen::VectorXd::LinSpaced(steps_, start_pos[idof], end_pos[idof]);
   }
 
   // Populate Cost Info
@@ -218,7 +218,7 @@ int main(int argc, char** argv)
   plotter->plotScene();
 
   // Set Log Level
-  gLogLevel = util::LevelInfo;
+  util::gLogLevel = util::LevelInfo;
 
   // Setup Problem
   TrajOptProbPtr prob;
@@ -240,7 +240,7 @@ int main(int argc, char** argv)
 
   ROS_INFO((found) ? ("Initial trajectory is in collision") : ("Initial trajectory is collision free"));
 
-  BasicTrustRegionSQP opt(prob);
+  sco::BasicTrustRegionSQP opt(prob);
   if (plotting_)
   {
     opt.addCallback(PlotCallback(*prob, plotter));

--- a/trajopt_examples/src/puzzle_piece_auxillary_axes_plan.cpp
+++ b/trajopt_examples/src/puzzle_piece_auxillary_axes_plan.cpp
@@ -227,7 +227,7 @@ int main(int argc, char** argv)
   plotter->plotScene();
 
   // Set Log Level
-  gLogLevel = util::LevelInfo;
+  util::gLogLevel = util::LevelInfo;
 
   // Setup Problem
   ProblemConstructionInfo pci = cppMethod();
@@ -246,7 +246,7 @@ int main(int argc, char** argv)
 
   ROS_INFO((found) ? ("Initial trajectory is in collision") : ("Initial trajectory is collision free"));
 
-  BasicTrustRegionSQP opt(prob);
+  sco::BasicTrustRegionSQP opt(prob);
   opt.setParameters(pci.opt_info);
   if (plotting_)
   {

--- a/trajopt_examples/src/puzzle_piece_plan.cpp
+++ b/trajopt_examples/src/puzzle_piece_plan.cpp
@@ -233,7 +233,7 @@ int main(int argc, char** argv)
   plotter->plotScene();
 
   // Set Log Level
-  gLogLevel = util::LevelInfo;
+  util::gLogLevel = util::LevelInfo;
 
   // Setup Problem
   ProblemConstructionInfo pci = cppMethod();
@@ -252,7 +252,7 @@ int main(int argc, char** argv)
 
   ROS_INFO((found) ? ("Initial trajectory is in collision") : ("Initial trajectory is collision free"));
 
-  BasicTrustRegionSQP opt(prob);
+  sco::BasicTrustRegionSQP opt(prob);
   opt.setParameters(pci.opt_info);
   if (plotting_)
   {

--- a/trajopt_sco/include/trajopt_sco/bpmpd_interface.hpp
+++ b/trajopt_sco/include/trajopt_sco/bpmpd_interface.hpp
@@ -7,12 +7,12 @@ namespace sco
 class BPMPDModel : public Model
 {
 public:
-  vector<Var> m_vars;
-  vector<Cnt> m_cnts;
-  vector<AffExpr> m_cntExprs;
-  vector<ConstraintType> m_cntTypes;
-  vector<double> m_soln;
-  vector<double> m_lbs, m_ubs;
+  VarVector m_vars;
+  CntVector m_cnts;
+  AffExprVector m_cntExprs;
+  ConstraintTypeVector m_cntTypes;
+  DblVec m_soln;
+  DblVec m_lbs, m_ubs;
 
   QuadExpr m_objective;
 
@@ -21,20 +21,20 @@ public:
   BPMPDModel();
   virtual ~BPMPDModel();
 
-  Var addVar(const string& name);
-  Cnt addEqCnt(const AffExpr&, const string& name);
-  Cnt addIneqCnt(const AffExpr&, const string& name);
-  Cnt addIneqCnt(const QuadExpr&, const string& name);
+  Var addVar(const std::string& name);
+  Cnt addEqCnt(const AffExpr&, const std::string& name);
+  Cnt addIneqCnt(const AffExpr&, const std::string& name);
+  Cnt addIneqCnt(const QuadExpr&, const std::string& name);
   void removeVars(const VarVector& vars);
-  void removeCnts(const vector<Cnt>& cnts);
+  void removeCnts(const CntVector& cnts);
 
   void update();
-  void setVarBounds(const vector<Var>& vars, const vector<double>& lower, const vector<double>& upper);
-  vector<double> getVarValues(const VarVector& vars) const;
+  void setVarBounds(const VarVector& vars, const DblVec& lower, const DblVec& upper);
+  DblVec getVarValues(const VarVector& vars) const;
   virtual CvxOptStatus optimize();
   virtual void setObjective(const AffExpr&);
   virtual void setObjective(const QuadExpr&);
-  virtual void writeToFile(const string& fname);
+  virtual void writeToFile(const std::string& fname);
   virtual VarVector getVars() const;
 };
 }

--- a/trajopt_sco/include/trajopt_sco/bpmpd_io.hpp
+++ b/trajopt_sco/include/trajopt_sco/bpmpd_io.hpp
@@ -1,12 +1,9 @@
 #include <string>
 #include <vector>
-using std::string;
-using std::vector;
 #include <assert.h>
 #include <iostream>
 #include <stdlib.h>
 #include <unistd.h>
-using namespace std;
 
 namespace bpmpd_io
 {
@@ -41,7 +38,7 @@ void ser(int fp, T& x, SerMode mode)
 }
 
 template <typename T>
-void ser(int fp, vector<T>& x, SerMode mode)
+void ser(int fp, std::vector<T>& x, SerMode mode)
 {
   int size = x.size();
   ser(fp, size, mode);
@@ -66,11 +63,11 @@ void ser(int fp, vector<T>& x, SerMode mode)
 struct bpmpd_input
 {
   int m, n, nz, qn, qnz;
-  vector<int> acolcnt, acolidx;
-  vector<double> acolnzs;
-  vector<int> qcolcnt, qcolidx;
-  vector<double> qcolnzs;
-  vector<double> rhs, obj, lbound, ubound;
+  std::vector<int> acolcnt, acolidx;
+  std::vector<double> acolnzs;
+  std::vector<int> qcolcnt, qcolidx;
+  std::vector<double> qcolnzs;
+  std::vector<double> rhs, obj, lbound, ubound;
 
   bpmpd_input() {}
   bpmpd_input(int m,
@@ -78,16 +75,16 @@ struct bpmpd_input
               int nz,
               int qn,
               int qnz,
-              const vector<int>& acolcnt,
-              const vector<int>& acolidx,
-              const vector<double>& acolnzs,
-              const vector<int>& qcolcnt,
-              const vector<int>& qcolidx,
-              const vector<double>& qcolnzs,
-              const vector<double>& rhs,
-              const vector<double>& obj,
-              const vector<double>& lbound,
-              const vector<double>& ubound)
+              const std::vector<int>& acolcnt,
+              const std::vector<int>& acolidx,
+              const std::vector<double>& acolnzs,
+              const std::vector<int>& qcolcnt,
+              const std::vector<int>& qcolidx,
+              const std::vector<double>& qcolnzs,
+              const std::vector<double>& rhs,
+              const std::vector<double>& obj,
+              const std::vector<double>& lbound,
+              const std::vector<double>& ubound)
     : m(m)
     , n(n)
     , nz(nz)
@@ -138,14 +135,14 @@ void ser(int fp, bpmpd_input& bi, SerMode mode)
 
 struct bpmpd_output
 {
-  vector<double> primal, dual;
-  vector<int> status;
+  std::vector<double> primal, dual;
+  std::vector<int> status;
   int code;
   double opt;
   bpmpd_output() {}
-  bpmpd_output(const vector<double>& primal,
-               const vector<double>& dual,
-               const vector<int>& status,
+  bpmpd_output(const std::vector<double>& primal,
+               const std::vector<double>& dual,
+               const std::vector<int>& status,
                int code,
                double opt)
     : primal(primal), dual(dual), status(status), code(code), opt(opt)

--- a/trajopt_sco/include/trajopt_sco/expr_vec_ops.hpp
+++ b/trajopt_sco/include/trajopt_sco/expr_vec_ops.hpp
@@ -3,11 +3,7 @@
 
 namespace sco
 {
-using Eigen::MatrixXd;
-using Eigen::VectorXd;
-
 #if 0
-typedef vector<AffExpr> ExprVector;
 Matrix3d leftCrossProdMat(const Vector3d& x);
 Matrix3d rightCrossProdMat(const Vector3d& x);
 
@@ -20,8 +16,8 @@ ExprVector exprCross(const VectorXd& x, const ExprVector& y);
 ExprVector exprCross(const ExprVector& x, const VectorXd& y);
 
 #endif
-AffExpr varDot(const VectorXd& x, const VarVector& v);
-AffExpr exprDot(const VectorXd& x, const AffExprVector& v);
+AffExpr varDot(const Eigen::VectorXd& x, const VarVector& v);
+AffExpr exprDot(const Eigen::VectorXd& x, const AffExprVector& v);
 #if 0
 QuadExpr varNorm2(const VarVector& v);
 QuadExpr exprNorm2(const ExprVector& v);

--- a/trajopt_sco/include/trajopt_sco/gurobi_interface.hpp
+++ b/trajopt_sco/include/trajopt_sco/gurobi_interface.hpp
@@ -17,24 +17,24 @@ class GurobiModel : public Model
 {
 public:
   GRBmodel* m_model;
-  vector<Var> m_vars;
-  vector<Cnt> m_cnts;
+  VarVector m_vars;
+  CntVector m_cnts;
 
   GurobiModel();
 
-  Var addVar(const string& name);
-  Var addVar(const string& name, double lower, double upper);
+  Var addVar(const std::string& name);
+  Var addVar(const std::string& name, double lower, double upper);
 
-  Cnt addEqCnt(const AffExpr&, const string& name);
-  Cnt addIneqCnt(const AffExpr&, const string& name);
-  Cnt addIneqCnt(const QuadExpr&, const string& name);
+  Cnt addEqCnt(const AffExpr&, const std::string& name);
+  Cnt addIneqCnt(const AffExpr&, const std::string& name);
+  Cnt addIneqCnt(const QuadExpr&, const std::string& name);
 
-  void removeVars(const vector<Var>&);
-  void removeCnts(const vector<Cnt>&);
+  void removeVars(const VarVector&);
+  void removeCnts(const CntVector&);
 
   void update();
-  void setVarBounds(const std::vector<Var>&, const std::vector<double>& lower, const std::vector<double>& upper);
-  vector<double> getVarValues(const vector<Var>&) const;
+  void setVarBounds(const VarVector&, const DblVec& lower, const DblVec& upper);
+  DblVec getVarValues(const VarVector&) const;
 
   CvxOptStatus optimize();
   /** Don't use this function, because it adds constraints that aren't tracked
@@ -43,7 +43,7 @@ public:
 
   void setObjective(const AffExpr&);
   void setObjective(const QuadExpr&);
-  void writeToFile(const string& fname);
+  void writeToFile(const std::string& fname);
 
   VarVector getVars() const;
 

--- a/trajopt_sco/include/trajopt_sco/modeling.hpp
+++ b/trajopt_sco/include/trajopt_sco/modeling.hpp
@@ -14,7 +14,6 @@
 
 namespace sco
 {
-using std::vector;
 
 /**
 Stores convex terms in a objective
@@ -39,16 +38,16 @@ public:
   bool inModel() { return model_ != NULL; }
   void addConstraintsToModel();
   void removeFromModel();
-  double value(const vector<double>& x);
+  double value(const DblVec& x);
 
   ~ConvexObjective();
 
   Model* model_;
   QuadExpr quad_;
-  vector<Var> vars_;
-  vector<AffExpr> eqs_;
-  vector<AffExpr> ineqs_;
-  vector<Cnt> cnts_;
+  VarVector vars_;
+  AffExprVector eqs_;
+  AffExprVector ineqs_;
+  CntVector cnts_;
 
 private:
   ConvexObjective() {}
@@ -76,16 +75,16 @@ public:
   void addConstraintsToModel();
   void removeFromModel();
 
-  vector<double> violations(const vector<double>& x);
-  double violation(const vector<double>& x);
+  DblVec violations(const DblVec& x);
+  double violation(const DblVec& x);
 
   ~ConvexConstraints();
-  vector<AffExpr> eqs_;
-  vector<AffExpr> ineqs_;
+  AffExprVector eqs_;
+  AffExprVector ineqs_;
 
 private:
   Model* model_;
-  vector<Cnt> cnts_;
+  CntVector cnts_;
   ConvexConstraints() : model_(NULL) {}
   ConvexConstraints(ConvexConstraints&) {}
 };
@@ -98,18 +97,18 @@ class Cost
 {
 public:
   /** Evaluate at solution vector x*/
-  virtual double value(const vector<double>&) = 0;
+  virtual double value(const DblVec&) = 0;
   /** Convexify at solution vector x*/
-  virtual ConvexObjectivePtr convex(const vector<double>& x, Model* model) = 0;
+  virtual ConvexObjectivePtr convex(const DblVec& x, Model* model) = 0;
   /** Get problem variables associated with this cost */
   virtual VarVector getVars() { return VarVector(); }
-  string name() { return name_; }
-  void setName(const string& name) { name_ = name; }
+  std::string name() { return name_; }
+  void setName(const std::string& name) { name_ = name; }
   Cost() : name_("unnamed") {}
-  Cost(const string& name) : name_(name) {}
+  Cost(const std::string& name) : name_(name) {}
   virtual ~Cost() {}
 protected:
-  string name_;
+  std::string name_;
 };
 
 /**
@@ -122,23 +121,23 @@ public:
   /** inequality vs equality */
   virtual ConstraintType type() = 0;
   /** Evaluate at solution vector x*/
-  virtual vector<double> value(const vector<double>& x) = 0;
+  virtual DblVec value(const DblVec& x) = 0;
   /** Convexify at solution vector x*/
-  virtual ConvexConstraintsPtr convex(const vector<double>& x, Model* model) = 0;
+  virtual ConvexConstraintsPtr convex(const DblVec& x, Model* model) = 0;
   /** Calculate constraint violations (positive part for inequality constraint,
    * absolute value for inequality constraint)*/
-  vector<double> violations(const vector<double>& x);
+  DblVec violations(const DblVec& x);
   /** Sum of violations */
-  double violation(const vector<double>& x);
+  double violation(const DblVec& x);
   /** Get problem variables associated with this constraint */
   virtual VarVector getVars() { return VarVector(); }
-  string name() { return name_; }
-  void setName(const string& name) { name_ = name; }
+  std::string name() { return name_; }
+  void setName(const std::string& name) { name_ = name; }
   Constraint() : name_("unnamed") {}
-  Constraint(const string& name) : name_(name) {}
+  Constraint(const std::string& name) : name_(name) {}
   virtual ~Constraint() {}
 protected:
-  string name_;
+  std::string name_;
 };
 
 class EqConstraint : public Constraint
@@ -161,17 +160,17 @@ class OptProb
 public:
   OptProb();
   /** create variables with bounds [-INFINITY, INFINITY]  */
-  VarVector createVariables(const vector<string>& names);
+  VarVector createVariables(const std::vector<std::string>& names);
   /** create variables with bounds [lb[i], ub[i] */
-  VarVector createVariables(const vector<string>& names, const vector<double>& lb, const vector<double>& ub);
+  VarVector createVariables(const std::vector<std::string>& names, const DblVec& lb, const DblVec& ub);
   /** set the lower bounds of all the variables */
-  void setLowerBounds(const vector<double>& lb);
+  void setLowerBounds(const DblVec& lb);
   /** set the upper bounds of all the variables */
-  void setUpperBounds(const vector<double>& ub);
+  void setUpperBounds(const DblVec& ub);
   /** set lower bounds of some of the variables */
-  void setLowerBounds(const vector<double>& lb, const vector<Var>& vars);
+  void setLowerBounds(const DblVec& lb, const VarVector& vars);
   /** set upper bounds of some of the variables */
-  void setUpperBounds(const vector<double>& ub, const vector<Var>& vars);
+  void setUpperBounds(const DblVec& ub, const VarVector& vars);
   /** Note: in the current implementation, this function just adds the
    * constraint to the
    * model. So if you're not careful, you might end up with an infeasible
@@ -186,28 +185,28 @@ public:
   virtual ~OptProb() {}
   /** Find closest point to solution vector x that satisfies linear inequality
    * constraints */
-  vector<double> getCentralFeasiblePoint(const vector<double>& x);
-  vector<double> getClosestFeasiblePoint(const vector<double>& x);
+  DblVec getCentralFeasiblePoint(const DblVec& x);
+  DblVec getClosestFeasiblePoint(const DblVec& x);
 
-  vector<ConstraintPtr> getConstraints() const;
-  const vector<CostPtr>& getCosts()  { return costs_; }
-  const vector<ConstraintPtr>& getIneqConstraints() { return ineqcnts_; }
-  const vector<ConstraintPtr>& getEqConstraints() { return eqcnts_; }
+  std::vector<ConstraintPtr> getConstraints() const;
+  const std::vector<CostPtr>& getCosts()  { return costs_; }
+  const std::vector<ConstraintPtr>& getIneqConstraints() { return ineqcnts_; }
+  const std::vector<ConstraintPtr>& getEqConstraints() { return eqcnts_; }
   const DblVec& getLowerBounds() { return lower_bounds_; }
   const DblVec& getUpperBounds() { return upper_bounds_; }
   ModelPtr getModel() { return model_; }
-  const vector<Var>& getVars() { return vars_; }
+  const VarVector& getVars() { return vars_; }
   int getNumCosts() { return costs_.size(); }
   int getNumConstraints() { return eqcnts_.size() + ineqcnts_.size(); }
   int getNumVars() { return vars_.size(); }
 protected:
   ModelPtr model_;
-  vector<Var> vars_;
-  vector<double> lower_bounds_;
-  vector<double> upper_bounds_;
-  vector<CostPtr> costs_;
-  vector<ConstraintPtr> eqcnts_;
-  vector<ConstraintPtr> ineqcnts_;
+  VarVector vars_;
+  DblVec lower_bounds_;
+  DblVec upper_bounds_;
+  std::vector<CostPtr> costs_;
+  std::vector<ConstraintPtr> eqcnts_;
+  std::vector<ConstraintPtr> ineqcnts_;
 
   OptProb(OptProb&);
 };
@@ -222,7 +221,7 @@ inline void setVec(DblVec& x, const VarVector& vars, const VecType& vals)
   }
 }
 template <typename OutVecType>
-inline OutVecType getVec1(const vector<double>& x, const VarVector& vars)
+inline OutVecType getVec1(const DblVec& x, const VarVector& vars)
 {
   OutVecType out(vars.size());
   for (unsigned i = 0; i < vars.size(); ++i)

--- a/trajopt_sco/include/trajopt_sco/modeling_utils.hpp
+++ b/trajopt_sco/include/trajopt_sco/modeling_utils.hpp
@@ -7,8 +7,6 @@
 @brief Build problem from user-defined functions
 Utilities for creating Cost and Constraint objects from functions
 using numerical derivatives or user-defined analytic derivatives.
-
-
  */
 
 namespace sco
@@ -20,29 +18,26 @@ enum PenaltyType
   HINGE
 };
 
-using Eigen::VectorXd;
-using Eigen::MatrixXd;
-
 /**
 x is the big solution vector of the whole problem. vars are variables that
 index into the vector x
 this function extracts (from x) the values of the variables in vars
  */
-VectorXd getVec(const vector<double>& x, const VarVector& vars);
+Eigen::VectorXd getVec(const DblVec& x, const VarVector& vars);
 /**
 Same idea as above, but different output type
  */
-DblVec getDblVec(const vector<double>& x, const VarVector& vars);
+DblVec getDblVec(const DblVec& x, const VarVector& vars);
 
-AffExpr affFromValGrad(double y, const VectorXd& x, const VectorXd& dydx, const VarVector& vars);
+AffExpr affFromValGrad(double y, const Eigen::VectorXd& x, const Eigen::VectorXd& dydx, const VarVector& vars);
 
 class CostFromFunc : public Cost
 {
 public:
   /// supply function, obtain derivative and hessian numerically
-  CostFromFunc(ScalarOfVectorPtr f, const VarVector& vars, const string& name, bool full_hessian = false);
-  double value(const vector<double>& x);
-  ConvexObjectivePtr convex(const vector<double>& x, Model* model);
+  CostFromFunc(ScalarOfVectorPtr f, const VarVector& vars, const std::string& name, bool full_hessian = false);
+  double value(const DblVec& x);
+  ConvexObjectivePtr convex(const DblVec& x, Model* model);
   VarVector getVars() { return vars_; }
 protected:
   ScalarOfVectorPtr f_;
@@ -57,24 +52,24 @@ public:
   /// supply error function, obtain derivative numerically
   CostFromErrFunc(VectorOfVectorPtr f,
                   const VarVector& vars,
-                  const VectorXd& coeffs,
+                  const Eigen::VectorXd& coeffs,
                   PenaltyType pen_type,
-                  const string& name);
+                  const std::string& name);
   /// supply error function and gradient
   CostFromErrFunc(VectorOfVectorPtr f,
                   MatrixOfVectorPtr dfdx,
                   const VarVector& vars,
-                  const VectorXd& coeffs,
+                  const Eigen::VectorXd& coeffs,
                   PenaltyType pen_type,
-                  const string& name);
-  double value(const vector<double>& x);
-  ConvexObjectivePtr convex(const vector<double>& x, Model* model);
+                  const std::string& name);
+  double value(const DblVec& x);
+  ConvexObjectivePtr convex(const DblVec& x, Model* model);
   VarVector getVars() { return vars_; }
 protected:
   VectorOfVectorPtr f_;
   MatrixOfVectorPtr dfdx_;
   VarVector vars_;
-  VectorXd coeffs_;
+  Eigen::VectorXd coeffs_;
   PenaltyType pen_type_;
   double epsilon_;
 };
@@ -85,27 +80,27 @@ public:
   /// supply error function, obtain derivative numerically
   ConstraintFromErrFunc(VectorOfVectorPtr f,
                      const VarVector& vars,
-                     const VectorXd& coeffs,
+                     const Eigen::VectorXd& coeffs,
                      ConstraintType type,
                      const std::string& name);
   /// supply error function and gradient
   ConstraintFromErrFunc(VectorOfVectorPtr f,
                      MatrixOfVectorPtr dfdx,
                      const VarVector& vars,
-                     const VectorXd& coeffs,
+                     const Eigen::VectorXd& coeffs,
                      ConstraintType type,
                      const std::string& name);
-  vector<double> value(const vector<double>& x);
-  ConvexConstraintsPtr convex(const vector<double>& x, Model* model);
+  DblVec value(const DblVec& x);
+  ConvexConstraintsPtr convex(const DblVec& x, Model* model);
   ConstraintType type() { return type_; }
   VarVector getVars() { return vars_; }
 protected:
   VectorOfVectorPtr f_;
   MatrixOfVectorPtr dfdx_;
   VarVector vars_;
-  VectorXd coeffs_;
+  Eigen::VectorXd coeffs_;
   ConstraintType type_;
   double epsilon_;
-  VectorXd scaling_;
+  Eigen::VectorXd scaling_;
 };
 }

--- a/trajopt_sco/include/trajopt_sco/num_diff.hpp
+++ b/trajopt_sco/include/trajopt_sco/num_diff.hpp
@@ -8,8 +8,6 @@
 
 namespace sco
 {
-using Eigen::VectorXd;
-using Eigen::MatrixXd;
 class ScalarOfVector;
 class VectorOfVector;
 class MatrixOfVector;
@@ -20,10 +18,10 @@ typedef std::shared_ptr<MatrixOfVector> MatrixOfVectorPtr;
 class ScalarOfVector
 {
 public:
-  virtual double operator()(const VectorXd& x) const = 0;
-  double call(const VectorXd& x) const { return operator()(x); }
+  virtual double operator()(const Eigen::VectorXd& x) const = 0;
+  double call(const Eigen::VectorXd& x) const { return operator()(x); }
   virtual ~ScalarOfVector() {}
-  typedef std::function<double(VectorXd)> func;
+  typedef std::function<double(Eigen::VectorXd)> func;
   static ScalarOfVectorPtr construct(const func&);
   //  typedef VectorXd (*c_func)(const VectorXd&);
   //  static ScalarOfVectorPtr construct(const c_func&);
@@ -31,10 +29,10 @@ public:
 class VectorOfVector
 {
 public:
-  virtual VectorXd operator()(const VectorXd& x) const = 0;
-  VectorXd call(const VectorXd& x) const { return operator()(x); }
+  virtual Eigen::VectorXd operator()(const Eigen::VectorXd& x) const = 0;
+  Eigen::VectorXd call(const Eigen::VectorXd& x) const { return operator()(x); }
   virtual ~VectorOfVector() {}
-  typedef std::function<VectorXd(VectorXd)> func;
+  typedef std::function<Eigen::VectorXd(Eigen::VectorXd)> func;
   static VectorOfVectorPtr construct(const func&);
   //  typedef VectorXd (*c_func)(const VectorXd&);
   //  static VectorOfVectorPtr construct(const c_func&);
@@ -42,24 +40,24 @@ public:
 class MatrixOfVector
 {
 public:
-  virtual MatrixXd operator()(const VectorXd& x) const = 0;
-  MatrixXd call(const VectorXd& x) const { return operator()(x); }
+  virtual Eigen::MatrixXd operator()(const Eigen::VectorXd& x) const = 0;
+  Eigen::MatrixXd call(const Eigen::VectorXd& x) const { return operator()(x); }
   virtual ~MatrixOfVector() {}
-  typedef std::function<MatrixXd(VectorXd)> func;
+  typedef std::function<Eigen::MatrixXd(Eigen::VectorXd)> func;
   static MatrixOfVectorPtr construct(const func&);
   //  typedef VectorMatrixXd (*c_func)(const VectorXd&);
   //  static MatrixOfVectorPtr construct(const c_func&);
 };
 
-VectorXd calcForwardNumGrad(const ScalarOfVector& f, const VectorXd& x, double epsilon);
-MatrixXd calcForwardNumJac(const VectorOfVector& f, const VectorXd& x, double epsilon);
+Eigen::VectorXd calcForwardNumGrad(const ScalarOfVector& f, const Eigen::VectorXd& x, double epsilon);
+Eigen::MatrixXd calcForwardNumJac(const VectorOfVector& f, const Eigen::VectorXd& x, double epsilon);
 void calcGradAndDiagHess(const ScalarOfVector& f,
-                         const VectorXd& x,
+                         const Eigen::VectorXd& x,
                          double epsilon,
                          double& y,
-                         VectorXd& grad,
-                         VectorXd& hess);
-void calcGradHess(ScalarOfVectorPtr f, const VectorXd& x, double epsilon, double& y, VectorXd& grad, MatrixXd& hess);
+                         Eigen::VectorXd& grad,
+                         Eigen::VectorXd& hess);
+void calcGradHess(ScalarOfVectorPtr f, const Eigen::VectorXd& x, double epsilon, double& y, Eigen::VectorXd& grad, Eigen::MatrixXd& hess);
 VectorOfVectorPtr forwardNumGrad(ScalarOfVectorPtr f, double epsilon);
 MatrixOfVectorPtr forwardNumJac(VectorOfVectorPtr f, double epsilon);
 }

--- a/trajopt_sco/include/trajopt_sco/optimizers.hpp
+++ b/trajopt_sco/include/trajopt_sco/optimizers.hpp
@@ -8,8 +8,6 @@
 
 namespace sco
 {
-using std::string;
-using std::vector;
 
 enum OptStatus
 {
@@ -24,7 +22,7 @@ static const char* OptStatus_strings[] = { "CONVERGED",
                                            "PENALTY_ITERATION_LIMIT",
                                            "FAILED",
                                            "INVALID" };
-inline string statusToString(OptStatus status) { return OptStatus_strings[status]; }
+inline std::string statusToString(OptStatus status) { return OptStatus_strings[status]; }
 struct OptResults
 {
   DblVec x;  // solution estimate
@@ -55,13 +53,13 @@ public:
   virtual OptStatus optimize() = 0;
   virtual ~Optimizer() {}
   virtual void setProblem(OptProbPtr prob) { prob_ = prob; }
-  void initialize(const vector<double>& x);
-  vector<double>& x() { return results_.x; }
+  void initialize(const DblVec& x);
+  DblVec& x() { return results_.x; }
   OptResults& results() { return results_; }
   typedef std::function<void(OptProb*, OptResults&)> Callback;
   void addCallback(const Callback& f);  // called before each iteration
 protected:
-  vector<Callback> callbacks_;
+  std::vector<Callback> callbacks_;
   void callCallbacks();
   OptProbPtr prob_;
   OptResults results_;
@@ -120,7 +118,7 @@ public:
 
 protected:
   void adjustTrustRegion(double ratio);
-  void setTrustBoxConstraints(const vector<double>& x);
+  void setTrustBoxConstraints(const DblVec& x);
   ModelPtr model_;
   BasicTrustRegionSQPParameters param_;
 };

--- a/trajopt_sco/include/trajopt_sco/sco_common.hpp
+++ b/trajopt_sco/include/trajopt_sco/sco_common.hpp
@@ -2,12 +2,16 @@
 #include <algorithm>
 #include <cmath>
 #include <vector>
+#include <trajopt_sco/sco_fwd.hpp>
 
 namespace sco
 {
-using std::vector;
-typedef vector<double> DblVec;
-typedef vector<unsigned char> BoolVec;
+typedef std::vector<double> DblVec;
+typedef std::vector<int> IntVec;
+typedef std::vector<Var> VarVector;
+typedef std::vector<AffExpr> AffExprVector;
+typedef std::vector<QuadExpr> QuadExprVector;
+typedef std::vector<Cnt> CntVector;
 
 inline double vecSum(const DblVec& v)
 {

--- a/trajopt_sco/src/bpmpd_caller.cpp
+++ b/trajopt_sco/src/bpmpd_caller.cpp
@@ -4,8 +4,6 @@
 #include <trajopt_sco/bpmpd_io.hpp>
 #include <trajopt_utils/stl_to_string.hpp>
 #include <unistd.h>
-using namespace bpmpd_io;
-using namespace std;
 
 extern "C" {
 extern void bpmpd(int*,
@@ -34,23 +32,23 @@ extern void bpmpd(int*,
 
 int main(int /*argc*/, char** /*argv*/)
 {
-  string working_dir = BPMPD_WORKING_DIR;
+  std::string working_dir = BPMPD_WORKING_DIR;
   int err = chdir(working_dir.c_str());
   if (err != 0)
   {
-    cerr << "error going to BPMPD working dir\n";
-    cerr << strerror(err) << endl;
+    std::cerr << "error going to BPMPD working dir\n";
+    std::cerr << strerror(err) << std::endl;
     abort();
   }
   // int counter=0;
   while (true)
   {
-    bpmpd_input bi;
-    ser(STDIN_FILENO, bi, DESER);
+    bpmpd_io::bpmpd_input bi;
+    bpmpd_io::ser(STDIN_FILENO, bi, bpmpd_io::DESER);
 
     int memsiz = 0;
     double BIG = 1e30;
-    bpmpd_output bo;
+    bpmpd_io::bpmpd_output bo;
     bo.primal.resize(bi.m + bi.n);
     bo.dual.resize(bi.m + bi.n);
     bo.status.resize(bi.m + bi.n);
@@ -95,6 +93,6 @@ int main(int /*argc*/, char** /*argv*/)
           &bo.opt,
           &memsiz);
 
-    ser(STDOUT_FILENO, bo, SER);
+    bpmpd_io::ser(STDOUT_FILENO, bo, bpmpd_io::SER);
   }
 }

--- a/trajopt_sco/src/bpmpd_interface.cpp
+++ b/trajopt_sco/src/bpmpd_interface.cpp
@@ -6,9 +6,6 @@
 #include <trajopt_utils/logging.hpp>
 #include <trajopt_utils/stl_to_string.hpp>
 
-using namespace std;
-using namespace bpmpd_io;
-
 /**
 This is a readme file for the linux DLL version of BPMPD version 2.21
 The DLL solves linear and convex quadratic problems.
@@ -151,9 +148,9 @@ double BIG = 1e+30;
 
 namespace sco
 {
-extern void simplify2(vector<int>& inds, vector<double>& vals);
-extern vector<int> vars2inds(const vector<Var>& vars);
-extern vector<int> cnts2inds(const vector<Cnt>& cnts);
+extern void simplify2(IntVec& inds, DblVec& vals);
+extern IntVec vars2inds(const VarVector& vars);
+extern IntVec cnts2inds(const CntVector& cnts);
 
 ModelPtr createBPMPDModel()
 {
@@ -209,7 +206,7 @@ int gPipeIn = 0, gPipeOut = 0;
 
 void fexit()
 {
-  char text[1] = { EXIT_CHAR };
+  char text[1] = { bpmpd_io::EXIT_CHAR };
   int n = write(gPipeIn, text, 1);
   ALWAYS_ASSERT(n == 1);
 }
@@ -234,42 +231,42 @@ BPMPDModel::~BPMPDModel()
   // m_pipeOut=0;
 }
 
-Var BPMPDModel::addVar(const string& name)
+Var BPMPDModel::addVar(const std::string& name)
 {
   m_vars.push_back(new VarRep(m_vars.size(), name, this));
   m_lbs.push_back(-BIG);
   m_ubs.push_back(BIG);
   return m_vars.back();
 }
-Cnt BPMPDModel::addEqCnt(const AffExpr& expr, const string& /*name*/)
+Cnt BPMPDModel::addEqCnt(const AffExpr& expr, const std::string& /*name*/)
 {
   m_cnts.push_back(new CntRep(m_cnts.size(), this));
   m_cntExprs.push_back(expr);
   m_cntTypes.push_back(EQ);
   return m_cnts.back();
 }
-Cnt BPMPDModel::addIneqCnt(const AffExpr& expr, const string& /*name*/)
+Cnt BPMPDModel::addIneqCnt(const AffExpr& expr, const std::string& /*name*/)
 {
   m_cnts.push_back(new CntRep(m_cnts.size(), this));
   m_cntExprs.push_back(expr);
   m_cntTypes.push_back(INEQ);
   return m_cnts.back();
 }
-Cnt BPMPDModel::addIneqCnt(const QuadExpr&, const string& /*name*/)
+Cnt BPMPDModel::addIneqCnt(const QuadExpr&, const std::string& /*name*/)
 {
   assert(0 && "NOT IMPLEMENTED");
   return 0;
 }
 void BPMPDModel::removeVars(const VarVector& vars)
 {
-  vector<int> inds = vars2inds(vars);
+  IntVec inds = vars2inds(vars);
   for (unsigned i = 0; i < vars.size(); ++i)
     vars[i].var_rep->removed = true;
 }
 
-void BPMPDModel::removeCnts(const vector<Cnt>& cnts)
+void BPMPDModel::removeCnts(const CntVector& cnts)
 {
-  vector<int> inds = cnts2inds(cnts);
+  IntVec inds = cnts2inds(cnts);
   for (unsigned i = 0; i < cnts.size(); ++i)
     cnts[i].cnt_rep->removed = true;
 }
@@ -318,7 +315,7 @@ void BPMPDModel::update()
   }
 }
 
-void BPMPDModel::setVarBounds(const vector<Var>& vars, const vector<double>& lower, const vector<double>& upper)
+void BPMPDModel::setVarBounds(const VarVector &vars, const DblVec &lower, const DblVec &upper)
 {
   for (unsigned i = 0; i < vars.size(); ++i)
   {
@@ -327,9 +324,9 @@ void BPMPDModel::setVarBounds(const vector<Var>& vars, const vector<double>& low
     m_ubs[varind] = upper[i];
   }
 }
-vector<double> BPMPDModel::getVarValues(const VarVector& vars) const
+DblVec BPMPDModel::getVarValues(const VarVector& vars) const
 {
-  vector<double> out(vars.size());
+  DblVec out(vars.size());
   for (unsigned i = 0; i < vars.size(); ++i)
   {
     int varind = vars[i].var_rep->index;
@@ -355,8 +352,8 @@ CvxOptStatus BPMPDModel::optimize()
   int n = m_vars.size();
   int m = m_cnts.size();
 
-  vector<int> acolcnt(n), acolidx, qcolcnt(n), qcolidx, status(m + n);
-  vector<double> acolnzs, qcolnzs, rhs(m), obj(n, 0), lbound(m + n), ubound(m + n), primal(m + n), dual(m + n);
+  IntVec acolcnt(n), acolidx, qcolcnt(n), qcolidx, status(m + n);
+  DblVec acolnzs, qcolnzs, rhs(m), obj(n, 0), lbound(m + n), ubound(m + n), primal(m + n), dual(m + n);
 
   DBG(m_lbs);
   DBG(m_ubs);
@@ -366,13 +363,13 @@ CvxOptStatus BPMPDModel::optimize()
     ubound[iVar] = fmin(m_ubs[iVar], BIG);
   }
 
-  vector<vector<int>> var2cntinds(n);
-  vector<vector<double>> var2cntvals(n);
+  std::vector<IntVec> var2cntinds(n);
+  std::vector<DblVec> var2cntvals(n);
   for (int iCnt = 0; iCnt < m; ++iCnt)
   {
     const AffExpr& aff = m_cntExprs[iCnt];
     // cout << "adding constraint " << aff << endl;
-    vector<int> inds = vars2inds(aff.vars);
+    IntVec inds = vars2inds(aff.vars);
 
     for (unsigned i = 0; i < aff.vars.size(); ++i)
     {
@@ -395,8 +392,8 @@ CvxOptStatus BPMPDModel::optimize()
   // cout << CSTR(acolidx) << endl;
   // cout << CSTR(acolnzs) << endl;
 
-  vector<vector<double>> var2qcoeffs(n);
-  vector<vector<int>> var2qinds(n);
+  std::vector<DblVec> var2qcoeffs(n);
+  std::vector<IntVec> var2qinds(n);
   for (unsigned i = 0; i < m_objective.size(); ++i)
   {
     int idx1 = m_objective.vars1[i].var_rep->index, idx2 = m_objective.vars2[i].var_rep->index;
@@ -463,7 +460,7 @@ CvxOptStatus BPMPDModel::optimize()
       primal.data(), dual.data(), status.data(), &BIG, &code, &opt, &memsiz);
 
   // opt += m_objective.affexpr.constant;
-  m_soln = vector<double>(primal.begin(), primal.begin()+n);
+  m_soln = DblVec(primal.begin(), primal.begin()+n);
 
 
   if (1) {
@@ -476,15 +473,15 @@ CvxOptStatus BPMPDModel::optimize()
 
 #else
 
-  bpmpd_input bi(m, n, nz, qn, qnz, acolcnt, acolidx, acolnzs, qcolcnt, qcolidx, qcolnzs, rhs, obj, lbound, ubound);
-  ser(gPipeIn, bi, SER);
+  bpmpd_io::bpmpd_input bi(m, n, nz, qn, qnz, acolcnt, acolidx, acolnzs, qcolcnt, qcolidx, qcolnzs, rhs, obj, lbound, ubound);
+  bpmpd_io::ser(gPipeIn, bi, bpmpd_io::SER);
 
   // std::cout << "serialization time:" << end-start << std::endl;
 
-  bpmpd_output bo;
-  ser(gPipeOut, bo, DESER);
+  bpmpd_io::bpmpd_output bo;
+  bpmpd_io::ser(gPipeOut, bo, bpmpd_io::DESER);
 
-  m_soln = vector<double>(bo.primal.begin(), bo.primal.begin() + n);
+  m_soln = DblVec(bo.primal.begin(), bo.primal.begin() + n);
   int retcode = bo.code;
 
   if (retcode == 2)
@@ -500,7 +497,7 @@ CvxOptStatus BPMPDModel::optimize()
 }
 void BPMPDModel::setObjective(const AffExpr& expr) { m_objective.affexpr = expr; }
 void BPMPDModel::setObjective(const QuadExpr& expr) { m_objective = expr; }
-void BPMPDModel::writeToFile(const string& /*fname*/)
+void BPMPDModel::writeToFile(const std::string& /*fname*/)
 {
   // assert(0 && "NOT IMPLEMENTED");
 }

--- a/trajopt_sco/src/expr_vec_ops.cpp
+++ b/trajopt_sco/src/expr_vec_ops.cpp
@@ -1,12 +1,12 @@
 #include <trajopt_sco/expr_vec_ops.hpp>
 namespace sco
 {
-AffExpr varDot(const VectorXd& x, const VarVector& v)
+AffExpr varDot(const Eigen::VectorXd& x, const VarVector& v)
 {
   AffExpr out;
   out.constant = 0;
   out.vars = v;
-  out.coeffs = vector<double>(x.data(), x.data() + x.size());
+  out.coeffs = DblVec(x.data(), x.data() + x.size());
   return out;
 }
 }

--- a/trajopt_sco/src/modeling.cpp
+++ b/trajopt_sco/src/modeling.cpp
@@ -8,8 +8,6 @@
 #include <trajopt_utils/logging.hpp>
 #include <trajopt_utils/macros.h>
 
-using namespace std;
-
 namespace sco
 {
 void ConvexObjective::addAffExpr(const AffExpr& affexpr) { exprInc(quad_, affexpr); }
@@ -30,7 +28,7 @@ void ConvexObjective::addAbs(const AffExpr& affexpr, double coeff)
   vars_.push_back(neg);
   vars_.push_back(pos);
   AffExpr neg_plus_pos;
-  neg_plus_pos.coeffs = vector<double>(2, coeff);
+  neg_plus_pos.coeffs = DblVec(2, coeff);
   neg_plus_pos.vars.push_back(neg);
   neg_plus_pos.vars.push_back(pos);
   exprInc(quad_, neg_plus_pos);
@@ -112,7 +110,7 @@ void ConvexConstraints::removeFromModel()
   model_ = NULL;
 }
 
-vector<double> ConvexConstraints::violations(const vector<double>& x)
+DblVec ConvexConstraints::violations(const DblVec& x)
 {
   DblVec out;
   out.reserve(eqs_.size() + ineqs_.size());
@@ -122,15 +120,15 @@ vector<double> ConvexConstraints::violations(const vector<double>& x)
     out.push_back(pospart(aff.value(x.data())));
   return out;
 }
-double ConvexConstraints::violation(const vector<double>& x) { return vecSum(violations(x)); }
+double ConvexConstraints::violation(const DblVec& x) { return vecSum(violations(x)); }
 ConvexConstraints::~ConvexConstraints()
 {
   if (inModel())
     removeFromModel();
 }
 
-double ConvexObjective::value(const vector<double>& x) { return quad_.value(x); }
-vector<double> Constraint::violations(const DblVec& x)
+double ConvexObjective::value(const DblVec& x) { return quad_.value(x); }
+DblVec Constraint::violations(const DblVec& x)
 {
   DblVec val = value(x);
   DblVec out(val.size());
@@ -151,11 +149,11 @@ vector<double> Constraint::violations(const DblVec& x)
 
 double Constraint::violation(const DblVec& x) { return vecSum(violations(x)); }
 OptProb::OptProb() : model_(createModel()) {}
-VarVector OptProb::createVariables(const vector<string>& var_names)
+VarVector OptProb::createVariables(const std::vector<std::string>& var_names)
 {
   return createVariables(var_names, DblVec(var_names.size(), -INFINITY), DblVec(var_names.size(), INFINITY));
 }
-VarVector OptProb::createVariables(const vector<string>& var_names, const DblVec& lb, const DblVec& ub)
+VarVector OptProb::createVariables(const std::vector<std::string>& var_names, const DblVec& lb, const DblVec& ub)
 {
   size_t n_add = var_names.size(), n_cur = vars_.size();
   assert(lb.size() == n_add);
@@ -172,18 +170,18 @@ VarVector OptProb::createVariables(const vector<string>& var_names, const DblVec
   model_->update();
   return VarVector(vars_.end() - n_add, vars_.end());
 }
-void OptProb::setLowerBounds(const vector<double>& lb)
+void OptProb::setLowerBounds(const DblVec& lb)
 {
   assert(lb.size() == vars_.size());
   lower_bounds_ = lb;
 }
-void OptProb::setUpperBounds(const vector<double>& ub)
+void OptProb::setUpperBounds(const DblVec& ub)
 {
   assert(ub.size() == vars_.size());
   upper_bounds_ = ub;
 }
-void OptProb::setLowerBounds(const vector<double>& lb, const vector<Var>& vars) { setVec(lower_bounds_, vars, lb); }
-void OptProb::setUpperBounds(const vector<double>& ub, const vector<Var>& vars) { setVec(upper_bounds_, vars, ub); }
+void OptProb::setLowerBounds(const DblVec& lb, const VarVector& vars) { setVec(lower_bounds_, vars, lb); }
+void OptProb::setUpperBounds(const DblVec& ub, const VarVector &vars) { setVec(upper_bounds_, vars, ub); }
 void OptProb::addCost(CostPtr cost) { costs_.push_back(cost); }
 void OptProb::addConstraint(ConstraintPtr cnt)
 {
@@ -202,9 +200,9 @@ void OptProb::addIneqConstraint(ConstraintPtr cnt)
   assert(cnt->type() == INEQ);
   ineqcnts_.push_back(cnt);
 }
-vector<ConstraintPtr> OptProb::getConstraints() const
+std::vector<ConstraintPtr> OptProb::getConstraints() const
 {
-  vector<ConstraintPtr> out;
+  std::vector<ConstraintPtr> out;
   out.reserve(eqcnts_.size() + ineqcnts_.size());
   out.insert(out.end(), eqcnts_.begin(), eqcnts_.end());
   out.insert(out.end(), ineqcnts_.begin(), ineqcnts_.end());
@@ -218,7 +216,7 @@ void OptProb::addLinearConstraint(const AffExpr& expr, ConstraintType type)
     model_->addIneqCnt(expr, "");
 }
 
-vector<double> OptProb::getCentralFeasiblePoint(const vector<double>& x)
+DblVec OptProb::getCentralFeasiblePoint(const DblVec& x)
 {
   assert(x.size() == lower_bounds_.size());
   DblVec center(x.size());
@@ -226,7 +224,7 @@ vector<double> OptProb::getCentralFeasiblePoint(const vector<double>& x)
     center[i] = (lower_bounds_[i] + upper_bounds_[i]) / 2;
   return getClosestFeasiblePoint(center);
 }
-vector<double> OptProb::getClosestFeasiblePoint(const vector<double>& x)
+DblVec OptProb::getClosestFeasiblePoint(const DblVec& x)
 {
   LOG_DEBUG("getClosestFeasiblePoint");
   assert(vars_.size() == x.size());

--- a/trajopt_sco/src/num_diff.cpp
+++ b/trajopt_sco/src/num_diff.cpp
@@ -1,6 +1,4 @@
 #include <trajopt_sco/num_diff.hpp>
-using namespace Eigen;
-using namespace sco;
 
 namespace sco
 {
@@ -10,7 +8,7 @@ ScalarOfVectorPtr ScalarOfVector::construct(const func& f)
   {
     func f;
     F(const func& _f) : f(_f) {}
-    double operator()(const VectorXd& x) const { return f(x); }
+    double operator()(const Eigen::VectorXd& x) const { return f(x); }
   };
   ScalarOfVector* sov = new F(f);  // to avoid erroneous clang warning
   return ScalarOfVectorPtr(sov);
@@ -21,16 +19,16 @@ VectorOfVectorPtr VectorOfVector::construct(const func& f)
   {
     func f;
     F(const func& _f) : f(_f) {}
-    VectorXd operator()(const VectorXd& x) const { return f(x); }
+    Eigen::VectorXd operator()(const Eigen::VectorXd& x) const { return f(x); }
   };
   VectorOfVector* vov = new F(f);  // to avoid erroneous clang warning
   return VectorOfVectorPtr(vov);
 }
 
-VectorXd calcForwardNumGrad(const ScalarOfVector& f, const VectorXd& x, double epsilon)
+Eigen::VectorXd calcForwardNumGrad(const ScalarOfVector& f, const Eigen::VectorXd& x, double epsilon)
 {
-  VectorXd out(x.size());
-  VectorXd xpert = x;
+  Eigen::VectorXd out(x.size());
+  Eigen::VectorXd xpert = x;
   double y = f(x);
   for (size_t i = 0; i < size_t(x.size()); ++i)
   {
@@ -41,15 +39,15 @@ VectorXd calcForwardNumGrad(const ScalarOfVector& f, const VectorXd& x, double e
   }
   return out;
 }
-MatrixXd calcForwardNumJac(const VectorOfVector& f, const VectorXd& x, double epsilon)
+Eigen::MatrixXd calcForwardNumJac(const VectorOfVector& f, const Eigen::VectorXd& x, double epsilon)
 {
-  VectorXd y = f(x);
-  MatrixXd out(y.size(), x.size());
-  VectorXd xpert = x;
+  Eigen::VectorXd y = f(x);
+  Eigen::MatrixXd out(y.size(), x.size());
+  Eigen::VectorXd xpert = x;
   for (size_t i = 0; i < size_t(x.size()); ++i)
   {
     xpert(i) = x(i) + epsilon;
-    VectorXd ypert = f(xpert);
+    Eigen::VectorXd ypert = f(xpert);
     out.col(i) = (ypert - y) / epsilon;
     xpert(i) = x(i);
   }
@@ -57,16 +55,16 @@ MatrixXd calcForwardNumJac(const VectorOfVector& f, const VectorXd& x, double ep
 }
 
 void calcGradAndDiagHess(const ScalarOfVector& f,
-                         const VectorXd& x,
+                         const Eigen::VectorXd& x,
                          double epsilon,
                          double& y,
-                         VectorXd& grad,
-                         VectorXd& hess)
+                         Eigen::VectorXd& grad,
+                         Eigen::VectorXd& hess)
 {
   y = f(x);
   grad.resize(x.size());
   hess.resize(x.size());
-  VectorXd xpert = x;
+  Eigen::VectorXd xpert = x;
   for (size_t i = 0; i < size_t(x.size()); ++i)
   {
     xpert(i) = x(i) + epsilon / 2;
@@ -79,7 +77,7 @@ void calcGradAndDiagHess(const ScalarOfVector& f,
   }
 }
 
-void calcGradHess(ScalarOfVectorPtr f, const VectorXd& x, double epsilon, double& y, VectorXd& grad, MatrixXd& hess)
+void calcGradHess(ScalarOfVectorPtr f, const Eigen::VectorXd& x, double epsilon, double& y, Eigen::VectorXd& grad, Eigen::MatrixXd& hess)
 {
   y = f->call(x);
   VectorOfVectorPtr grad_func = forwardNumGrad(f, epsilon);
@@ -93,7 +91,7 @@ struct ForwardNumGrad : public VectorOfVector
   ScalarOfVectorPtr f_;
   double epsilon_;
   ForwardNumGrad(ScalarOfVectorPtr f, double epsilon) : f_(f), epsilon_(epsilon) {}
-  VectorXd operator()(const VectorXd& x) const { return calcForwardNumGrad(*f_, x, epsilon_); }
+  Eigen::VectorXd operator()(const Eigen::VectorXd& x) const { return calcForwardNumGrad(*f_, x, epsilon_); }
 };
 
 struct ForwardNumJac : public MatrixOfVector
@@ -101,7 +99,7 @@ struct ForwardNumJac : public MatrixOfVector
   VectorOfVectorPtr f_;
   double epsilon_;
   ForwardNumJac(VectorOfVectorPtr f, double epsilon) : f_(f), epsilon_(epsilon) {}
-  MatrixXd operator()(const VectorXd& x) const { return calcForwardNumJac(*f_, x, epsilon_); }
+  Eigen::MatrixXd operator()(const Eigen::VectorXd& x) const { return calcForwardNumJac(*f_, x, epsilon_); }
 };
 
 VectorOfVectorPtr forwardNumGrad(ScalarOfVectorPtr f, double epsilon)

--- a/trajopt_sco/src/optimizers.cpp
+++ b/trajopt_sco/src/optimizers.cpp
@@ -10,21 +10,17 @@
 #include <trajopt_utils/macros.h>
 #include <trajopt_utils/stl_to_string.hpp>
 
-using namespace std;
-using namespace util;
-
 namespace sco
 {
-typedef vector<double> DblVec;
 
 std::ostream& operator<<(std::ostream& o, const OptResults& r)
 {
-  o << "Optimization results:" << endl
-    << "status: " << statusToString(r.status) << endl
-    << "cost values: " << Str(r.cost_vals) << endl
-    << "constraint violations: " << Str(r.cnt_viols) << endl
-    << "n func evals: " << r.n_func_evals << endl
-    << "n qp solves: " << r.n_qp_solves << endl;
+  o << "Optimization results:" << std::endl
+    << "status: " << statusToString(r.status) << std::endl
+    << "cost values: " << util::Str(r.cost_vals) << std::endl
+    << "constraint violations: " << util::Str(r.cnt_viols) << std::endl
+    << "n func evals: " << r.n_func_evals << std::endl
+    << "n qp solves: " << r.n_qp_solves << std::endl;
   return o;
 }
 
@@ -32,7 +28,7 @@ std::ostream& operator<<(std::ostream& o, const OptResults& r)
 ////////// private utility functions for  sqp /////////
 //////////////////////////////////////////////////
 
-static DblVec evaluateCosts(const vector<CostPtr>& costs, const DblVec& x)
+static DblVec evaluateCosts(const std::vector<CostPtr>& costs, const DblVec& x)
 {
   DblVec out(costs.size());
   for (size_t i = 0; i < costs.size(); ++i)
@@ -41,7 +37,7 @@ static DblVec evaluateCosts(const vector<CostPtr>& costs, const DblVec& x)
   }
   return out;
 }
-static DblVec evaluateConstraintViols(const vector<ConstraintPtr>& constraints, const DblVec& x)
+static DblVec evaluateConstraintViols(const std::vector<ConstraintPtr>& constraints, const DblVec& x)
 {
   DblVec out(constraints.size());
   for (size_t i = 0; i < constraints.size(); ++i)
@@ -50,18 +46,18 @@ static DblVec evaluateConstraintViols(const vector<ConstraintPtr>& constraints, 
   }
   return out;
 }
-static vector<ConvexObjectivePtr> convexifyCosts(const vector<CostPtr>& costs, const DblVec& x, Model* model)
+static std::vector<ConvexObjectivePtr> convexifyCosts(const std::vector<CostPtr>& costs, const DblVec& x, Model* model)
 {
-  vector<ConvexObjectivePtr> out(costs.size());
+  std::vector<ConvexObjectivePtr> out(costs.size());
   for (size_t i = 0; i < costs.size(); ++i)
   {
     out[i] = costs[i]->convex(x, model);
   }
   return out;
 }
-static vector<ConvexConstraintsPtr> convexifyConstraints(const vector<ConstraintPtr>& cnts, const DblVec& x, Model* model)
+static std::vector<ConvexConstraintsPtr> convexifyConstraints(const std::vector<ConstraintPtr>& cnts, const DblVec& x, Model* model)
 {
-  vector<ConvexConstraintsPtr> out(cnts.size());
+  std::vector<ConvexConstraintsPtr> out(cnts.size());
   for (size_t i = 0; i < cnts.size(); ++i)
   {
     out[i] = cnts[i]->convex(x, model);
@@ -69,7 +65,7 @@ static vector<ConvexConstraintsPtr> convexifyConstraints(const vector<Constraint
   return out;
 }
 
-DblVec evaluateModelCosts(const vector<ConvexObjectivePtr>& costs, const DblVec& x)
+DblVec evaluateModelCosts(const std::vector<ConvexObjectivePtr>& costs, const DblVec& x)
 {
   DblVec out(costs.size());
   for (size_t i = 0; i < costs.size(); ++i)
@@ -78,7 +74,7 @@ DblVec evaluateModelCosts(const vector<ConvexObjectivePtr>& costs, const DblVec&
   }
   return out;
 }
-DblVec evaluateModelCntViols(const vector<ConvexConstraintsPtr>& cnts, const DblVec& x)
+DblVec evaluateModelCntViols(const std::vector<ConvexConstraintsPtr>& cnts, const DblVec& x)
 {
   DblVec out(cnts.size());
   for (size_t i = 0; i < cnts.size(); ++i)
@@ -88,80 +84,80 @@ DblVec evaluateModelCntViols(const vector<ConvexConstraintsPtr>& cnts, const Dbl
   return out;
 }
 
-static vector<string> getCostNames(const vector<CostPtr>& costs)
+static std::vector<std::string> getCostNames(const std::vector<CostPtr>& costs)
 {
-  vector<string> out(costs.size());
+  std::vector<std::string> out(costs.size());
   for (size_t i = 0; i < costs.size(); ++i)
     out[i] = costs[i]->name();
   return out;
 }
-static vector<string> getCntNames(const vector<ConstraintPtr>& cnts)
+static std::vector<std::string> getCntNames(const std::vector<ConstraintPtr>& cnts)
 {
-  vector<string> out(cnts.size());
+  std::vector<std::string> out(cnts.size());
   for (size_t i = 0; i < cnts.size(); ++i)
     out[i] = cnts[i]->name();
   return out;
 }
 
-void printCostInfo(const vector<double>& old_cost_vals,
-                   const vector<double>& model_cost_vals,
-                   const vector<double>& new_cost_vals,
-                   const vector<double>& old_cnt_vals,
-                   const vector<double>& model_cnt_vals,
-                   const vector<double>& new_cnt_vals,
-                   const vector<string>& cost_names,
-                   const vector<string>& cnt_names,
+void printCostInfo(const DblVec& old_cost_vals,
+                   const DblVec& model_cost_vals,
+                   const DblVec& new_cost_vals,
+                   const DblVec& old_cnt_vals,
+                   const DblVec& model_cnt_vals,
+                   const DblVec& new_cnt_vals,
+                   const std::vector<std::string>& cost_names,
+                   const std::vector<std::string>& cnt_names,
                    double merit_coeff)
 {
-  printf("%15s | %10s | %10s | %10s | %10s\n", "", "oldexact", "dapprox", "dexact", "ratio");
-  printf("%15s | %10s---%10s---%10s---%10s\n", "COSTS", "----------", "----------", "----------", "----------");
+  std::printf("%15s | %10s | %10s | %10s | %10s\n", "", "oldexact", "dapprox", "dexact", "ratio");
+  std::printf("%15s | %10s---%10s---%10s---%10s\n", "COSTS", "----------", "----------", "----------", "----------");
   for (size_t i = 0; i < old_cost_vals.size(); ++i)
   {
     double approx_improve = old_cost_vals[i] - model_cost_vals[i];
     double exact_improve = old_cost_vals[i] - new_cost_vals[i];
     if (fabs(approx_improve) > 1e-8)
-      printf("%15s | %10.3e | %10.3e | %10.3e | %10.3e\n",
-             cost_names[i].c_str(),
-             old_cost_vals[i],
-             approx_improve,
-             exact_improve,
-             exact_improve / approx_improve);
+      std::printf("%15s | %10.3e | %10.3e | %10.3e | %10.3e\n",
+                  cost_names[i].c_str(),
+                  old_cost_vals[i],
+                  approx_improve,
+                  exact_improve,
+                  exact_improve / approx_improve);
     else
-      printf("%15s | %10.3e | %10.3e | %10.3e | %10s\n",
-             cost_names[i].c_str(),
-             old_cost_vals[i],
-             approx_improve,
-             exact_improve,
-             "  ------  ");
+      std::printf("%15s | %10.3e | %10.3e | %10.3e | %10s\n",
+                  cost_names[i].c_str(),
+                  old_cost_vals[i],
+                  approx_improve,
+                  exact_improve,
+                  "  ------  ");
   }
   if (cnt_names.size() == 0)
     return;
-  printf("%15s | %10s---%10s---%10s---%10s\n", "CONSTRAINTS", "----------", "----------", "----------", "----------");
+  std::printf("%15s | %10s---%10s---%10s---%10s\n", "CONSTRAINTS", "----------", "----------", "----------", "----------");
   for (size_t i = 0; i < old_cnt_vals.size(); ++i)
   {
     double approx_improve = old_cnt_vals[i] - model_cnt_vals[i];
     double exact_improve = old_cnt_vals[i] - new_cnt_vals[i];
     if (fabs(approx_improve) > 1e-8)
-      printf("%15s | %10.3e | %10.3e | %10.3e | %10.3e\n",
-             cnt_names[i].c_str(),
-             merit_coeff * old_cnt_vals[i],
-             merit_coeff * approx_improve,
-             merit_coeff * exact_improve,
-             exact_improve / approx_improve);
+      std::printf("%15s | %10.3e | %10.3e | %10.3e | %10.3e\n",
+                  cnt_names[i].c_str(),
+                  merit_coeff * old_cnt_vals[i],
+                  merit_coeff * approx_improve,
+                  merit_coeff * exact_improve,
+                  exact_improve / approx_improve);
     else
-      printf("%15s | %10.3e | %10.3e | %10.3e | %10s\n",
-             cnt_names[i].c_str(),
-             merit_coeff * old_cnt_vals[i],
-             merit_coeff * approx_improve,
-             merit_coeff * exact_improve,
-             "  ------  ");
+      std::printf("%15s | %10.3e | %10.3e | %10.3e | %10s\n",
+                  cnt_names[i].c_str(),
+                  merit_coeff * old_cnt_vals[i],
+                  merit_coeff * approx_improve,
+                  merit_coeff * exact_improve,
+                  "  ------  ");
   }
 }
 
 // todo: use different coeffs for each constraint
-vector<ConvexObjectivePtr> cntsToCosts(const vector<ConvexConstraintsPtr>& cnts, double err_coeff, Model* model)
+std::vector<ConvexObjectivePtr> cntsToCosts(const std::vector<ConvexConstraintsPtr>& cnts, double err_coeff, Model* model)
 {
-  vector<ConvexObjectivePtr> out;
+  std::vector<ConvexObjectivePtr> out;
   for (const ConvexConstraintsPtr& cnt : cnts)
   {
     ConvexObjectivePtr obj(new ConvexObjective(model));
@@ -187,7 +183,7 @@ void Optimizer::callCallbacks()
   }
 }
 
-void Optimizer::initialize(const vector<double>& x)
+void Optimizer::initialize(const DblVec &x)
 {
   if (!prob_)
     PRINT_AND_THROW("need to set the problem before initializing");
@@ -226,7 +222,7 @@ void BasicTrustRegionSQP::setProblem(OptProbPtr prob)
 void BasicTrustRegionSQP::adjustTrustRegion(double ratio) { param_.trust_box_size *= ratio; }
 void BasicTrustRegionSQP::setTrustBoxConstraints(const DblVec& x)
 {
-  const vector<Var>& vars = prob_->getVars();
+  const VarVector& vars = prob_->getVars();
   assert(vars.size() == x.size());
   const DblVec &lb = prob_->getLowerBounds(), ub = prob_->getUpperBounds();
   DblVec lbtrust(x.size()), ubtrust(x.size());
@@ -262,9 +258,9 @@ struct MultiCritFilter {
 
 OptStatus BasicTrustRegionSQP::optimize()
 {
-  vector<string> cost_names = getCostNames(prob_->getCosts());
-  vector<ConstraintPtr> constraints = prob_->getConstraints();
-  vector<string> cnt_names = getCntNames(constraints);
+  std::vector<std::string> cost_names = getCostNames(prob_->getCosts());
+  std::vector<ConstraintPtr> constraints = prob_->getConstraints();
+  std::vector<std::string> cnt_names = getCntNames(constraints);
 
   if (results_.x.size() == 0)
     PRINT_AND_THROW("you forgot to initialize!");
@@ -309,9 +305,9 @@ OptStatus BasicTrustRegionSQP::optimize()
       //   results_.cost_vals[i] << endl;
       // }
 
-      vector<ConvexObjectivePtr> cost_models = convexifyCosts(prob_->getCosts(), results_.x, model_.get());
-      vector<ConvexConstraintsPtr> cnt_models = convexifyConstraints(constraints, results_.x, model_.get());
-      vector<ConvexObjectivePtr> cnt_cost_models = cntsToCosts(cnt_models, param_.merit_error_coeff, model_.get());
+      std::vector<ConvexObjectivePtr> cost_models = convexifyCosts(prob_->getCosts(), results_.x, model_.get());
+      std::vector<ConvexConstraintsPtr> cnt_models = convexifyConstraints(constraints, results_.x, model_.get());
+      std::vector<ConvexObjectivePtr> cnt_cost_models = cntsToCosts(cnt_models, param_.merit_error_coeff, model_.get());
       model_->update();
       for (ConvexObjectivePtr& cost : cost_models)
         cost->addConstraintsToModel();
@@ -360,7 +356,7 @@ OptStatus BasicTrustRegionSQP::optimize()
         // the Model
         DblVec new_x(model_var_vals.begin(), model_var_vals.begin() + results_.x.size());
 
-        if (GetLogLevel() >= util::LevelDebug)
+        if (util::GetLogLevel() >= util::LevelDebug)
         {
           DblVec cnt_costs1 = evaluateModelCosts(cnt_cost_models, model_var_vals);
           DblVec cnt_costs2 = model_cnt_viols;
@@ -394,12 +390,12 @@ OptStatus BasicTrustRegionSQP::optimize()
                         cost_names,
                         cnt_names,
                         param_.merit_error_coeff);
-          printf("%15s | %10.3e | %10.3e | %10.3e | %10.3e\n",
-                 "TOTAL",
-                 old_merit,
-                 approx_merit_improve,
-                 exact_merit_improve,
-                 merit_improve_ratio);
+          std::printf("%15s | %10.3e | %10.3e | %10.3e | %10.3e\n",
+                      "TOTAL",
+                      old_merit,
+                      approx_merit_improve,
+                      exact_merit_improve,
+                      merit_improve_ratio);
         }
 
         if (approx_merit_improve < -1e-5)

--- a/trajopt_sco/src/solver_interface.cpp
+++ b/trajopt_sco/src/solver_interface.cpp
@@ -4,26 +4,25 @@
 #include <sstream>
 #include <trajopt_sco/solver_interface.hpp>
 #include <trajopt_utils/macros.h>
-using namespace std;
 
 namespace sco
 {
-vector<int> vars2inds(const vector<Var>& vars)
+IntVec vars2inds(const VarVector& vars)
 {
-  vector<int> inds(vars.size());
+  IntVec inds(vars.size());
   for (size_t i = 0; i < inds.size(); ++i)
     inds[i] = vars[i].var_rep->index;
   return inds;
 }
-vector<int> cnts2inds(const vector<Cnt>& cnts)
+IntVec cnts2inds(const CntVector& cnts)
 {
-  vector<int> inds(cnts.size());
+  IntVec inds(cnts.size());
   for (size_t i = 0; i < inds.size(); ++i)
     inds[i] = cnts[i].cnt_rep->index;
   return inds;
 }
 
-void simplify2(vector<int>& inds, vector<double>& vals)
+void simplify2(IntVec& inds, DblVec& vals)
 {
   typedef std::map<int, double> Int2Double;
   Int2Double ind2val;
@@ -52,7 +51,7 @@ double AffExpr::value(const double* x) const
   }
   return out;
 }
-double AffExpr::value(const vector<double>& x) const
+double AffExpr::value(const DblVec &x) const
 {
   double out = constant;
   for (size_t i = 0; i < size(); ++i)
@@ -61,7 +60,7 @@ double AffExpr::value(const vector<double>& x) const
   }
   return out;
 }
-double QuadExpr::value(const vector<double>& x) const
+double QuadExpr::value(const DblVec& x) const
 {
   double out = affexpr.value(x);
   for (size_t i = 0; i < size(); ++i)
@@ -80,7 +79,7 @@ double QuadExpr::value(const double* x) const
   return out;
 }
 
-Var Model::addVar(const string& name, double lb, double ub)
+Var Model::addVar(const std::string& name, double lb, double ub)
 {
   Var v = addVar(name);
   setVarBounds(v, lb, ub);
@@ -88,12 +87,12 @@ Var Model::addVar(const string& name, double lb, double ub)
 }
 void Model::removeVar(const Var& var)
 {
-  vector<Var> vars(1, var);
+  VarVector vars(1, var);
   removeVars(vars);
 }
 void Model::removeCnt(const Cnt& cnt)
 {
-  vector<Cnt> cnts(1, cnt);
+  CntVector cnts(1, cnt);
   removeCnts(cnts);
 }
 
@@ -105,12 +104,12 @@ double Model::getVarValue(const Var& var) const
 
 void Model::setVarBounds(const Var& var, double lower, double upper)
 {
-  vector<double> lowers(1, lower), uppers(1, upper);
-  vector<Var> vars(1, var);
+  DblVec lowers(1, lower), uppers(1, upper);
+  VarVector vars(1, var);
   setVarBounds(vars, lowers, uppers);
 }
 
-ostream& operator<<(ostream& o, const Var& v)
+std::ostream& operator<<(std::ostream& o, const Var& v)
 {
   if (v.var_rep != NULL)
     o << v.var_rep->name;
@@ -118,12 +117,12 @@ ostream& operator<<(ostream& o, const Var& v)
     o << "nullvar";
   return o;
 }
-ostream& operator<<(ostream& o, const Cnt& c)
+std::ostream& operator<<(std::ostream& o, const Cnt& c)
 {
   o << c.cnt_rep->expr << ((c.cnt_rep->type == EQ) ? " == 0" : " <= 0");
   return o;
 }
-ostream& operator<<(ostream& o, const AffExpr& e)
+std::ostream& operator<<(std::ostream& o, const AffExpr& e)
 {
   o << e.constant;
   for (size_t i = 0; i < e.size(); ++i)
@@ -132,7 +131,7 @@ ostream& operator<<(ostream& o, const AffExpr& e)
   }
   return o;
 }
-ostream& operator<<(ostream& o, const QuadExpr& e)
+std::ostream& operator<<(std::ostream& o, const QuadExpr& e)
 {
   o << e.affexpr;
   for (size_t i = 0; i < e.size(); ++i)
@@ -164,9 +163,9 @@ ModelPtr createModel()
 
   if (solver_env)
   {
-    if (string(solver_env) == "GUROBI")
+    if (std::string(solver_env) == "GUROBI")
       solver = GUROBI;
-    else if (string(solver_env) == "BPMPD")
+    else if (std::string(solver_env) == "BPMPD")
       solver = BPMPD;
     else
       PRINT_AND_THROW(boost::format("invalid solver \"%s\"specified by TRAJOPT_CONVEX_SOLVER") % solver_env);

--- a/trajopt_sco/test/small-problems-unit.cpp
+++ b/trajopt_sco/test/small-problems-unit.cpp
@@ -47,7 +47,7 @@ TEST(SQP, QuadraticSeparable)
   BasicTrustRegionSQP solver(prob);
   BasicTrustRegionSQPParameters &params = solver.getParameters();
   params.trust_box_size = 100;
-  vector<double> x = {3, 4, 5};
+  DblVec x = {3, 4, 5};
   solver.initialize(x);
   OptStatus status = solver.optimize();
   ASSERT_EQ(status, OPT_CONVERGED);
@@ -66,7 +66,7 @@ TEST(SQP, QuadraticNonseparable)
   params.trust_box_size = 100;
   params.min_trust_box_size = 1e-5;
   params.min_approx_improve = 1e-6;
-  vector<double> x = {3, 4, 5};
+  DblVec x = {3, 4, 5};
   solver.initialize(x);
   OptStatus status = solver.optimize();
   ASSERT_EQ(status, OPT_CONVERGED);

--- a/trajopt_sco/test/solver-interface-unit.cpp
+++ b/trajopt_sco/test/solver-interface-unit.cpp
@@ -6,14 +6,12 @@
 #include <trajopt_utils/logging.hpp>
 #include <trajopt_utils/stl_to_string.hpp>
 
-using namespace std;
-
 using namespace sco;
 
 TEST(solver_interface, setup_problem)
 {
   ModelPtr solver = createModel();
-  vector<Var> vars;
+  VarVector vars;
   for (int i = 0; i < 3; ++i)
   {
     char namebuf[5];
@@ -23,14 +21,14 @@ TEST(solver_interface, setup_problem)
   solver->update();
 
   AffExpr aff;
-  cout << aff << endl;
+  std::cout << aff << std::endl;
   for (int i = 0; i < 3; ++i)
   {
     exprInc(aff, vars[i]);
     solver->setVarBounds(vars[i], 0, 10);
   }
   aff.constant -= 3;
-  cout << aff << endl;
+  std::cout << aff << std::endl;
   QuadExpr affsquared = exprSquare(aff);
   solver->setObjective(affsquared);
   solver->update();
@@ -40,7 +38,7 @@ TEST(solver_interface, setup_problem)
 
   solver->optimize();
 
-  vector<double> soln(3);
+  DblVec soln(3);
   for (int i = 0; i < 3; ++i)
   {
     soln[i] = solver->getVarValue(vars[i]);
@@ -56,7 +54,7 @@ TEST(solver_interface, setup_problem)
 TEST(ExprMult_test1, setup_problem)
 {
   ModelPtr solver = createModel();
-  vector<Var> vars;
+  VarVector vars;
   for (int i = 0; i < 3; ++i)
   {
     char namebuf[5];
@@ -72,17 +70,17 @@ TEST(ExprMult_test1, setup_problem)
   solver->update();
 
   AffExpr aff1;
-  cout << aff1 << endl;
+  std::cout << aff1 << std::endl;
   for (int i = 0; i < 3; ++i)
   {
     exprInc(aff1, vars[i]);
     solver->setVarBounds(vars[i], 0, 10);
   }
   aff1.constant -= 3;
-  cout << aff1 << endl;
+  std::cout << aff1 << std::endl;
 
   AffExpr aff2;
-  cout << aff2 << endl;
+  std::cout << aff2 << std::endl;
   for (int i = 3; i < 6; ++i)
   {
     exprInc(aff2, vars[i]);
@@ -90,7 +88,7 @@ TEST(ExprMult_test1, setup_problem)
   }
   aff2.constant -= 5;
 
-  cout << aff2 << endl;
+  std::cout << aff2 << std::endl;
   QuadExpr aff12 = exprMult(aff1, aff2);
   solver->setObjective(aff12);
   solver->update();
@@ -100,7 +98,7 @@ TEST(ExprMult_test1, setup_problem)
 
   solver->optimize();
 
-  vector<double> soln(3);
+  DblVec soln(3);
   for (int i = 0; i < 3; ++i)
   {
     soln[i] = solver->getVarValue(vars[i]);
@@ -123,7 +121,7 @@ TEST(ExprMult_test2, setup_problem)
   const double aff2_const = 0;
 
   ModelPtr solver = createModel();
-  vector<Var> vars;
+  VarVector vars;
   vars.push_back(solver->addVar("v1"));
   vars.push_back(solver->addVar("v2"));
 
@@ -142,8 +140,8 @@ TEST(ExprMult_test2, setup_problem)
   aff2.constant = aff2_const;
   aff2.coeffs[0] = v2_coeff;
 
-  cout << "aff1: " << aff1 << endl;
-  cout << "aff2: " << aff2 << endl;
+  std::cout << "aff1: " << aff1 << std::endl;
+  std::cout << "aff2: " << aff2 << std::endl;
   QuadExpr aff12 = exprMult(aff1, aff2);
   solver->setObjective(aff12);
   solver->update();
@@ -153,13 +151,13 @@ TEST(ExprMult_test2, setup_problem)
 
   solver->optimize();
 
-  vector<double> soln(2);
+  DblVec soln(2);
   for (int i = 0; i < 2; ++i)
   {
     soln[i] = solver->getVarValue(vars[i]);
-    cout << soln[i] << endl;
+    std::cout << soln[i] << std::endl;
   }
-  cout << "Result: " << aff12.value(soln) << endl;
+  std::cout << "Result: " << aff12.value(soln) << std::endl;
   double answer = (v1_coeff * v1_val + aff1_const) * (v2_coeff * v2_val + aff2_const);
   EXPECT_NEAR(aff12.value(soln), answer, 1e-6);
 }
@@ -175,7 +173,7 @@ TEST(ExprMult_test3, setup_problem)
   const double aff2_const = -5;
 
   ModelPtr solver = createModel();
-  vector<Var> vars;
+  VarVector vars;
   vars.push_back(solver->addVar("v1"));
   vars.push_back(solver->addVar("v2"));
 
@@ -194,8 +192,8 @@ TEST(ExprMult_test3, setup_problem)
   aff2.constant = aff2_const;
   aff2.coeffs[0] = v2_coeff;
 
-  cout << "aff1: " << aff1 << endl;
-  cout << "aff2: " << aff2 << endl;
+  std::cout << "aff1: " << aff1 << std::endl;
+  std::cout << "aff2: " << aff2 << std::endl;
   QuadExpr aff12 = exprMult(aff1, aff2);
   solver->setObjective(aff12);
   solver->update();
@@ -205,13 +203,13 @@ TEST(ExprMult_test3, setup_problem)
 
   solver->optimize();
 
-  vector<double> soln(2);
+  DblVec soln(2);
   for (int i = 0; i < 2; ++i)
   {
     soln[i] = solver->getVarValue(vars[i]);
-    cout << soln[i] << endl;
+    std::cout << soln[i] << std::endl;
   }
-  cout << "Result: " << aff12.value(soln) << endl;
+  std::cout << "Result: " << aff12.value(soln) << std::endl;
   double answer = (v1_coeff * v1_val + aff1_const) * (v2_coeff * v2_val + aff2_const);
   EXPECT_NEAR(aff12.value(soln), answer, 1e-6);
 }

--- a/trajopt_utils/include/trajopt_utils/stl_to_string.hpp
+++ b/trajopt_utils/include/trajopt_utils/stl_to_string.hpp
@@ -7,15 +7,13 @@
 #include <vector>
 namespace util
 {
-using std::string;
-using std::vector;
 
 // std::string Str(const vector<double>& x);
 // std::string Str(const vector<float>& x);
 // std::string Str(const vector<int>& x);
 
 template <class T>
-std::string Str(const vector<T>& x)
+std::string Str(const std::vector<T>& x)
 {
   std::stringstream ss;
   ss << "(";

--- a/trajopt_utils/src/config.cpp
+++ b/trajopt_utils/src/config.cpp
@@ -1,5 +1,4 @@
 #include <trajopt_utils/config.hpp>
-using namespace std;
 
 namespace util
 {

--- a/trajopt_utils/src/logging.cpp
+++ b/trajopt_utils/src/logging.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <string>
 #include <trajopt_utils/logging.hpp>
-using namespace std;
 
 namespace util
 {
@@ -13,16 +12,16 @@ int LoggingInit()
   const char* VALID_THRESH_VALUES = "FATAL ERROR WARN INFO DEBUG TRACE";
 
   char* lvlc = getenv("TRAJOPT_LOG_THRESH");
-  string lvlstr;
+  std::string lvlstr;
   if (lvlc == NULL)
   {
-    printf("You can set logging level with TRAJOPT_LOG_THRESH. Valid values: "
-           "%s. Defaulting to INFO\n",
-           VALID_THRESH_VALUES);
+    std::printf("You can set logging level with TRAJOPT_LOG_THRESH. Valid values: "
+                "%s. Defaulting to INFO\n",
+                VALID_THRESH_VALUES);
     lvlstr = "INFO";
   }
   else
-    lvlstr = string(lvlc);
+    lvlstr = std::string(lvlc);
   if (lvlstr == "FATAL")
     gLogLevel = LevelFatal;
   else if (lvlstr == "ERROR")
@@ -37,8 +36,8 @@ int LoggingInit()
     gLogLevel = LevelTrace;
   else
   {
-    printf("Invalid value for environment variable TRAJOPT_LOG_THRESH: %s\n", lvlstr.c_str());
-    printf("Valid values: %s\n", VALID_THRESH_VALUES);
+    std::printf("Invalid value for environment variable TRAJOPT_LOG_THRESH: %s\n", lvlstr.c_str());
+    std::printf("Valid values: %s\n", VALID_THRESH_VALUES);
     abort();
   }
   return 1;

--- a/trajopt_utils/src/stl_to_string.cpp
+++ b/trajopt_utils/src/stl_to_string.cpp
@@ -1,14 +1,13 @@
 #include <sstream>
 #include <trajopt_utils/stl_to_string.hpp>
 #include <vector>
-using namespace std;
 
 namespace
 {
 template <class T>
-std::string Str_impl(const vector<T>& x)
+std::string Str_impl(const std::vector<T>& x)
 {
-  stringstream ss;
+  std::stringstream ss;
   ss << "(";
   if (x.size() > 0)
     ss << x[0];
@@ -21,7 +20,7 @@ std::string Str_impl(const vector<T>& x)
 
 namespace util
 {
-std::string Str(const vector<double>& x) { return Str_impl(x); }
-std::string Str(const vector<float>& x) { return Str_impl(x); }
-std::string Str(const vector<int>& x) { return Str_impl(x); }
+std::string Str(const std::vector<double>& x) { return Str_impl(x); }
+std::string Str(const std::vector<float>& x) { return Str_impl(x); }
+std::string Str(const std::vector<int>& x) { return Str_impl(x); }
 }


### PR DESCRIPTION
This is a major clean up for trajopt removing a lot of the `using namespaces`. I remove the use from all header files and from most cpp if it was not significant.