### PR TITLE
Set OSQP verbosity to false

### DIFF
--- a/trajopt_sco/src/osqp_interface.cpp
+++ b/trajopt_sco/src/osqp_interface.cpp
@@ -32,6 +32,7 @@ OSQPModel::OSQPModel()
   osqp_settings_.eps_rel = 1e-6;
   osqp_settings_.max_iter = 8192;
   osqp_settings_.polish = 1;
+  osqp_settings_.verbose = false;
 
   // Initialize data
   osqp_data_.A = nullptr;


### PR DESCRIPTION
This keeps it from spamming the terminal when running TrajOpt many times in a row.