### PR TITLE
Fix format string

### DIFF
--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -244,7 +244,7 @@ void ProblemConstructionInfo::readInitInfo(const Json::Value& v)
     if (endpoint.size() != static_cast<unsigned>(n_dof))
     {
       PRINT_AND_THROW(boost::format("wrong number of dof values in "
-                                    "initialization. expected %i got %j") %
+                                    "initialization. expected %i got %i") %
                       n_dof % endpoint.size());
     }
     init_info.data = util::toVectorXd(endpoint);


### PR DESCRIPTION
Otherwise one gets
```
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::io::bad_format_string> >'
  what():  boost::bad_format_string: format-string is ill-formed
```