### PR TITLE
Fix calcCollision to filter link specific distance threshold

### DIFF
--- a/trajopt/include/trajopt/utils.hpp
+++ b/trajopt/include/trajopt/utils.hpp
@@ -73,7 +73,7 @@ struct SafetyMarginData
    * @param safety_margin_coeffs A safety margin coefficient vector where each
    * element corresponds to a given timestep.
    */
-  void SetPairSafetyMarginData(const std::string& obj1,
+  void setPairSafetyMarginData(const std::string& obj1,
                                const std::string& obj2,
                                const double& safety_margin,
                                const double& safety_margin_coeff)
@@ -89,6 +89,15 @@ struct SafetyMarginData
     }
   }
 
+  /**
+   * @brief Get the pairs safety margin data
+   *
+   * If a safety margin for the request pair does not exist it returns the default safety margin data.
+   *
+   * @param obj1 The first object name
+   * @param obj2 The second object name
+   * @return A Vector2d[Contact Distance Threshold, Coefficient]
+   */
   const Eigen::Vector2d& getPairSafetyMarginData(const std::string& obj1, const std::string& obj2) const
   {
     const std::string& key = obj1 + obj2;
@@ -104,6 +113,13 @@ struct SafetyMarginData
     }
   }
 
+  /**
+   * @brief Get the max safety margin data
+   *
+   * This used when setting the contact distance in the contact manager.
+   *
+   * @return Max contact distance threshold
+   */
   const double& getMaxSafetyMargin() const { return max_safety_margin_; }
 
 private:

--- a/trajopt/src/collision_terms.cpp
+++ b/trajopt/src/collision_terms.cpp
@@ -321,7 +321,19 @@ void SingleTimestepCollisionEvaluator::CalcCollisions(const DblVec& x,
     contact_manager_->setCollisionObjectsTransform(link_name, state->transforms[link_name]);
 
   contact_manager_->contactTest(contacts, tesseract_collision::ContactTestType::ALL);
-  tesseract_collision::flattenResults(std::move(contacts), dist_results);
+
+  tesseract_collision::ContactResultVector temp;
+  tesseract_collision::flattenResults(std::move(contacts), temp);
+
+  // Because each pair can have its own contact distance we need to
+  // filter out collision pairs that are outside the pairs threshold
+  dist_results.reserve(temp.size());
+  for (auto& res : temp)
+  {
+    const Eigen::Vector2d& data = getSafetyMarginData()->getPairSafetyMarginData(res.link_names[0], res.link_names[1]);
+    if (data[0] > res.distance)
+      dist_results.emplace_back(res);
+  }
 }
 
 void SingleTimestepCollisionEvaluator::CalcDists(const DblVec& x, DblVec& dists)
@@ -407,7 +419,19 @@ void CastCollisionEvaluator::CalcCollisions(const DblVec& x, tesseract_collision
         link_name, state0->transforms[link_name], state1->transforms[link_name]);
 
   contact_manager_->contactTest(contacts, tesseract_collision::ContactTestType::ALL);
-  tesseract_collision::flattenResults(std::move(contacts), dist_results);
+
+  tesseract_collision::ContactResultVector temp;
+  tesseract_collision::flattenResults(std::move(contacts), temp);
+
+  // Because each pair can have its own contact distance we need to
+  // filter out collision pairs that are outside the pairs threshold
+  dist_results.reserve(temp.size());
+  for (auto& res : temp)
+  {
+    const Eigen::Vector2d& data = getSafetyMarginData()->getPairSafetyMarginData(res.link_names[0], res.link_names[1]);
+    if (data[0] > res.distance)
+      dist_results.emplace_back(res);
+  }
 }
 void CastCollisionEvaluator::CalcDistExpressions(const DblVec& x, sco::AffExprVector& exprs)
 {

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -1401,7 +1401,7 @@ void CollisionTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value
         SafetyMarginData::Ptr& data = info[index];
         for (auto j = 0u; j < pair.size(); ++j)
         {
-          data->SetPairSafetyMarginData(link, pair[j], pair_dist_pen[index], pair_coeffs[index]);
+          data->setPairSafetyMarginData(link, pair[j], pair_dist_pen[index], pair_coeffs[index]);
         }
       }
     }

--- a/trajopt_sco/include/trajopt_sco/bpmpd_io.hpp
+++ b/trajopt_sco/include/trajopt_sco/bpmpd_io.hpp
@@ -25,13 +25,13 @@ void ser(int fp, T& x, SerMode mode)
     case SER:
     {
       T xcopy = x;
-      long n = write(fp, &xcopy, sizeof(T));
+      ssize_t n = write(fp, &xcopy, sizeof(T));
       assert(n == sizeof(T));
       break;
     }
     case DESER:
     {
-      long n = read(fp, &x, sizeof(T));
+      ssize_t n = read(fp, &x, sizeof(T));
       assert(n == sizeof(T));
       break;
     }


### PR DESCRIPTION
This was an oversight on my part when I added the ability to add link specific distance threshold. The filtering was occurring in convex and value function but not in the calcCollision so cost function were being added for pairs that were outside the threshold. This was causing issues because cost returned from the value function and the sum of the constants from the cost function were not even close as a result. This was causing issues with the optimizer as you would expect.

Also this fixes an issues I ran into with a return type. 