### PR TITLE
Add Plot Callback that doesn't require the problem

### DIFF
--- a/trajopt/include/trajopt/plot_callback.hpp
+++ b/trajopt/include/trajopt/plot_callback.hpp
@@ -12,4 +12,13 @@ well as all of the Cost and Constraint functions with plot methods
 */
 sco::Optimizer::Callback TRAJOPT_API PlotCallback(TrajOptProb& prob,
                                                   const tesseract_visualization::Visualization::Ptr& plotter);
+/**
+ * @brief Returns a callback suitable for an optimizer but does not require the problem
+ * @param plotter
+ * @param joint_names
+ * @return
+ */
+sco::Optimizer::Callback TRAJOPT_API PlotProbCallback(const tesseract_visualization::Visualization::Ptr& plotter,
+                                                      const std::vector<std::string>& joint_names);
+
 }  // namespace trajopt

--- a/trajopt/src/plot_callback.cpp
+++ b/trajopt/src/plot_callback.cpp
@@ -53,4 +53,44 @@ sco::Optimizer::Callback PlotCallback(TrajOptProb& prob, const tesseract_visuali
                    std::ref(prob.GetVars()),
                    std::placeholders::_2);
 }
+
+void PlotProb(const tesseract_visualization::Visualization::Ptr& plotter,
+              const std::vector<std::string>& joint_names,
+              sco::OptProb* prob,
+              const sco::OptResults& results)
+{
+  plotter->clear();
+
+  for (const sco::Cost::Ptr& cost : prob->getCosts())
+  {
+    if (Plotter* plt = dynamic_cast<Plotter*>(cost.get()))
+    {
+      plt->Plot(plotter, results.x);
+    }
+  }
+
+  for (const sco::Constraint::Ptr& cnt : prob->getConstraints())
+  {
+    if (Plotter* plt = dynamic_cast<Plotter*>(cnt.get()))
+    {
+      plt->Plot(plotter, results.x);
+    }
+  }
+  auto var_vec = prob->getVars();
+  // This probably is/should be a utility somewhere
+  VarArray var_array;
+  var_array.m_data = var_vec;
+  var_array.m_nCol = joint_names.size();
+  var_array.m_nRow = var_vec.size() / var_array.cols();
+
+  plotter->plotTrajectory(joint_names, getTraj(results.x, var_array));
+  plotter->waitForInput();
+}
+
+sco::Optimizer::Callback PlotProbCallback(const tesseract_visualization::Visualization::Ptr& plotter,
+                                          const std::vector<std::string>& joint_names)
+{
+  return std::bind(&PlotProb, plotter, joint_names, std::placeholders::_1, std::placeholders::_2);
+}
+
 }  // namespace trajopt


### PR DESCRIPTION
This is important when using Tesseract Planner, and you do not have access to the problem at creation time.