### PR TITLE
Dynamic Cartesian Pose Error Calculator Update

### DIFF
--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -1,4 +1,4 @@
-﻿#include <trajopt_utils/macros.h>
+#include <trajopt_utils/macros.h>
 TRAJOPT_IGNORE_WARNINGS_PUSH
 #include <boost/algorithm/string.hpp>
 TRAJOPT_IGNORE_WARNINGS_POP
@@ -606,7 +606,7 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
         prob.GetEnv()->getSceneGraph(), prob.GetKin()->getActiveLinkNames(), state->transforms);
 
     sco::VectorOfVector::Ptr f(
-        new DynamicCartPoseErrCalculator(target, prob.GetKin(), adjacency_map, world_to_base, link, tcp));
+        new DynamicCartPoseErrCalculator(target, prob.GetKin(), adjacency_map, world_to_base, link, tcp, target_tcp));
     // Apply error calculator as either cost or constraint
     if (term_type & TT_COST)
     {


### PR DESCRIPTION
The `DynamicCartPoseErrCalculator` class was previously not being constructed with the target TCP transform, thus all target points sat at the origin of the frame they were associated with