### PR TITLE
Cartesian Pose Term Info from frame relative transform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
     - ROS_REPO=ros
     - NOT_TEST_INSTALL=true
     - CMAKE_ARGS=-DENABLE_TESTS=ON
+    - BUILD_PKGS_WHITELIST="trajopt trajopt_sco trajopt_tools trajopt_utils"
 
 matrix:
   include:

--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -260,6 +260,8 @@ struct CartPoseTermInfo : public TermInfo
   std::string link;
   /** @brief Static transform applied to the link */
   Eigen::Isometry3d tcp;
+  /** @brief The frame relative to which the target position is defined */
+  std::string target;
 
   CartPoseTermInfo();
 

--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -221,6 +221,7 @@ struct DynamicCartPoseTermInfo : public TermInfo
 
   /** @brief Timestep at which to apply term */
   int timestep;
+  /** @brief The link relative to which the target_tcp is defined */
   std::string target;
   /** @brief Coefficients for position and rotation */
   Eigen::Vector3d pos_coeffs, rot_coeffs;
@@ -260,7 +261,8 @@ struct CartPoseTermInfo : public TermInfo
   std::string link;
   /** @brief Static transform applied to the link */
   Eigen::Isometry3d tcp;
-  /** @brief The frame relative to which the target position is defined */
+  /** @brief The frame relative to which the target position is defined. If empty, frame is assumed to the root,
+   * "world", frame */
   std::string target;
 
   CartPoseTermInfo();

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -636,10 +636,7 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
     }
     catch (const std::exception&)
     {
-      std::stringstream ss;
-      ss << "Failed to find transform for link '" + prob.GetKin()->getBaseLinkName() +
-                "'; using identity transform instead";
-      CONSOLE_BRIDGE_logError(ss.str().c_str());
+      PRINT_AND_THROW(boost::format("Failed to find transform for link '%s'") % prob.GetKin()->getBaseLinkName());
     }
     tesseract_environment::AdjacencyMap::Ptr adjacency_map = std::make_shared<tesseract_environment::AdjacencyMap>(
         prob.GetEnv()->getSceneGraph(), prob.GetKin()->getActiveLinkNames(), state->transforms);
@@ -737,10 +734,7 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
   }
   catch (const std::exception&)
   {
-    std::stringstream ss;
-    ss << "Failed to find transform for link '" + prob.GetKin()->getBaseLinkName() +
-              "'; using identity transform instead";
-    CONSOLE_BRIDGE_logError(ss.str().c_str());
+    PRINT_AND_THROW(boost::format("Failed to find transform for link '%s'") % prob.GetKin()->getBaseLinkName());
   }
 
   Eigen::Isometry3d world_to_target = Eigen::Isometry3d::Identity();
@@ -750,9 +744,7 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
   }
   catch (const std::exception& ex)
   {
-    std::stringstream ss;
-    ss << "Failed to find transform for link '" + target + "'; using identity transform instead";
-    CONSOLE_BRIDGE_logError(ss.str().c_str());
+    PRINT_AND_THROW(boost::format("Failed to find transform for link '%s'") % target);
   }
 
   tesseract_environment::AdjacencyMap::Ptr adjacency_map = std::make_shared<tesseract_environment::AdjacencyMap>(
@@ -850,10 +842,7 @@ void CartVelTermInfo::hatch(TrajOptProb& prob)
   }
   catch (const std::exception&)
   {
-    std::stringstream ss;
-    ss << "Failed to find transform for link '" + prob.GetKin()->getBaseLinkName() +
-              "'; using identity transform instead";
-    CONSOLE_BRIDGE_logError(ss.str().c_str());
+    PRINT_AND_THROW(boost::format("Failed to find transform for link '%s'") % prob.GetKin()->getBaseLinkName());
   }
 
   tesseract_environment::AdjacencyMap::Ptr adjacency_map = std::make_shared<tesseract_environment::AdjacencyMap>(
@@ -1558,10 +1547,7 @@ void CollisionTermInfo::hatch(TrajOptProb& prob)
   }
   catch (const std::exception&)
   {
-    std::stringstream ss;
-    ss << "Failed to find transform for link '" + prob.GetKin()->getBaseLinkName() +
-              "'; using identity transform instead";
-    CONSOLE_BRIDGE_logError(ss.str().c_str());
+    PRINT_AND_THROW(boost::format("Failed to find transform for link '%s'") % prob.GetKin()->getBaseLinkName());
   }
 
   tesseract_environment::AdjacencyMap::Ptr adjacency_map = std::make_shared<tesseract_environment::AdjacencyMap>(

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -629,8 +629,17 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
   else
   {
     tesseract_environment::EnvState::ConstPtr state = prob.GetEnv()->getCurrentState();
-    Eigen::Isometry3d world_to_base = state->transforms.at(prob.GetKin()->getBaseLinkName());
-
+    Eigen::Isometry3d world_to_base = Eigen::Isometry3d::Identity();
+    try
+    {
+      world_to_base = state->transforms.at(prob.GetKin()->getBaseLinkName());
+    }
+    catch (const std::exception&)
+    {
+      std::stringstream ss;
+      ss << "Failed to find transform for link '" + prob.GetKin()->getBaseLinkName() + "'; using identity transform instead";
+      CONSOLE_BRIDGE_logError(ss.str().c_str());
+    }
     tesseract_environment::AdjacencyMap::Ptr adjacency_map = std::make_shared<tesseract_environment::AdjacencyMap>(
         prob.GetEnv()->getSceneGraph(), prob.GetKin()->getActiveLinkNames(), state->transforms);
 
@@ -712,8 +721,29 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
   input_pose.translation() = xyz;
 
   tesseract_environment::EnvState::ConstPtr state = prob.GetEnv()->getCurrentState();
-  Eigen::Isometry3d world_to_base = state->transforms.at(prob.GetKin()->getBaseLinkName());
-  Eigen::Isometry3d base_to_target = state->transforms.at(target);
+  Eigen::Isometry3d world_to_base = Eigen::Isometry3d::Identity();
+  try
+  {
+    world_to_base = state->transforms.at(prob.GetKin()->getBaseLinkName());
+  }
+  catch(const std::exception&)
+  {
+    std::stringstream ss;
+    ss << "Failed to find transform for link '" + prob.GetKin()->getBaseLinkName() + "'; using identity transform instead";
+    CONSOLE_BRIDGE_logError(ss.str().c_str());
+  }
+
+  Eigen::Isometry3d base_to_target = Eigen::Isometry3d::Identity();
+  try
+  {
+    base_to_target = state->transforms.at(target);
+  }
+  catch (const std::exception& ex)
+  {
+    std::stringstream ss;
+    ss << "Failed to find transform for link '" + prob.GetKin()->getBaseLinkName() + "'; using identity transform instead";
+    CONSOLE_BRIDGE_logError(ss.str().c_str());
+  }
 
   tesseract_environment::AdjacencyMap::Ptr adjacency_map = std::make_shared<tesseract_environment::AdjacencyMap>(
       prob.GetEnv()->getSceneGraph(), prob.GetKin()->getActiveLinkNames(), state->transforms);
@@ -803,7 +833,18 @@ void CartVelTermInfo::hatch(TrajOptProb& prob)
   int n_dof = static_cast<int>(prob.GetKin()->numJoints());
 
   tesseract_environment::EnvState::ConstPtr state = prob.GetEnv()->getCurrentState();
-  Eigen::Isometry3d world_to_base = state->transforms.at(prob.GetKin()->getBaseLinkName());
+  Eigen::Isometry3d world_to_base = Eigen::Isometry3d::Identity();
+  try
+  {
+    world_to_base = state->transforms.at(prob.GetKin()->getBaseLinkName());
+  }
+  catch(const std::exception&)
+  {
+    std::stringstream ss;
+    ss << "Failed to find transform for link '" + prob.GetKin()->getBaseLinkName() + "'; using identity transform instead";
+    CONSOLE_BRIDGE_logError(ss.str().c_str());
+  }
+
   tesseract_environment::AdjacencyMap::Ptr adjacency_map = std::make_shared<tesseract_environment::AdjacencyMap>(
       prob.GetEnv()->getSceneGraph(), prob.GetKin()->getActiveLinkNames(), state->transforms);
 
@@ -1499,7 +1540,18 @@ void CollisionTermInfo::hatch(TrajOptProb& prob)
 {
   int n_dof = static_cast<int>(prob.GetKin()->numJoints());
   tesseract_environment::EnvState::ConstPtr state = prob.GetEnv()->getCurrentState();
-  Eigen::Isometry3d world_to_base = state->transforms.at(prob.GetKin()->getBaseLinkName());
+  Eigen::Isometry3d world_to_base = Eigen::Isometry3d::Identity();
+  try
+  {
+    world_to_base = state->transforms.at(prob.GetKin()->getBaseLinkName());
+  }
+  catch(const std::exception&)
+  {
+    std::stringstream ss;
+    ss << "Failed to find transform for link '" + prob.GetKin()->getBaseLinkName() + "'; using identity transform instead";
+    CONSOLE_BRIDGE_logError(ss.str().c_str());
+  }
+
   tesseract_environment::AdjacencyMap::Ptr adjacency_map = std::make_shared<tesseract_environment::AdjacencyMap>(
       prob.GetEnv()->getSceneGraph(), prob.GetKin()->getActiveLinkNames(), state->transforms);
 

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -630,6 +630,7 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
   {
     tesseract_environment::EnvState::ConstPtr state = prob.GetEnv()->getCurrentState();
     Eigen::Isometry3d world_to_base = state->transforms.at(prob.GetKin()->getBaseLinkName());
+
     tesseract_environment::AdjacencyMap::Ptr adjacency_map = std::make_shared<tesseract_environment::AdjacencyMap>(
         prob.GetEnv()->getSceneGraph(), prob.GetKin()->getActiveLinkNames(), state->transforms);
 
@@ -679,6 +680,7 @@ void CartPoseTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value&
   json_marshal::childFromJson(params, link, "link");
   json_marshal::childFromJson(params, tcp_xyz, "tcp_xyz", Eigen::Vector3d(0, 0, 0));
   json_marshal::childFromJson(params, tcp_wxyz, "tcp_wxyz", Eigen::Vector4d(1, 0, 0, 0));
+  json_marshal::childFromJson(params, target, "target", std::string(""));
 
   Eigen::Quaterniond q(tcp_wxyz(0), tcp_wxyz(1), tcp_wxyz(2), tcp_wxyz(3));
   tcp.linear() = q.matrix();
@@ -690,7 +692,13 @@ void CartPoseTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value&
     PRINT_AND_THROW(boost::format("invalid link name: %s") % link);
   }
 
-  const char* all_fields[] = { "timestep", "xyz", "wxyz", "pos_coeffs", "rot_coeffs", "link", "tcp_xyz", "tcp_wxyz" };
+  const std::vector<std::string>& all_links = pci.env->getLinkNames();
+  if (std::find(all_links.begin(), all_links.end(), target) == all_links.end())
+  {
+    PRINT_AND_THROW(boost::format("invalid target link name: %s") % target);
+  }
+
+  const char* all_fields[] = { "timestep", "xyz", "wxyz", "pos_coeffs", "rot_coeffs", "link", "tcp_xyz", "tcp_wxyz", "target"};
   ensure_only_members(params, all_fields, sizeof(all_fields) / sizeof(char*));
 }
 
@@ -705,6 +713,8 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
 
   tesseract_environment::EnvState::ConstPtr state = prob.GetEnv()->getCurrentState();
   Eigen::Isometry3d world_to_base = state->transforms.at(prob.GetKin()->getBaseLinkName());
+  Eigen::Isometry3d base_to_target = state->transforms.at(target);
+
   tesseract_environment::AdjacencyMap::Ptr adjacency_map = std::make_shared<tesseract_environment::AdjacencyMap>(
       prob.GetEnv()->getSceneGraph(), prob.GetKin()->getActiveLinkNames(), state->transforms);
 
@@ -745,7 +755,7 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
   else if ((term_type & TT_COST) && ~(term_type | ~TT_USE_TIME))
   {
     sco::VectorOfVector::Ptr f(
-        new CartPoseErrCalculator(input_pose, prob.GetKin(), adjacency_map, world_to_base, link, tcp, indices));
+        new CartPoseErrCalculator(base_to_target * input_pose, prob.GetKin(), adjacency_map, world_to_base, link, tcp, indices));
     sco::MatrixOfVector::Ptr dfdx(
         new CartPoseJacCalculator(input_pose, prob.GetKin(), adjacency_map, world_to_base, link, tcp, indices));
     prob.addCost(
@@ -754,7 +764,7 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
   else if ((term_type & TT_CNT) && ~(term_type | ~TT_USE_TIME))
   {
     sco::VectorOfVector::Ptr f(
-        new CartPoseErrCalculator(input_pose, prob.GetKin(), adjacency_map, world_to_base, link, tcp, indices));
+        new CartPoseErrCalculator(base_to_target * input_pose, prob.GetKin(), adjacency_map, world_to_base, link, tcp, indices));
     sco::MatrixOfVector::Ptr dfdx(
         new CartPoseJacCalculator(input_pose, prob.GetKin(), adjacency_map, world_to_base, link, tcp, indices));
     prob.addConstraint(sco::Constraint::Ptr(

--- a/trajopt/test/data/config/numerical_ik1.json
+++ b/trajopt/test/data/config/numerical_ik1.json
@@ -13,7 +13,8 @@
       "wxyz" : [0,0,1,0],
       "link" : "l_gripper_tool_frame",
       "pos_coeffs" : [10, 10, 10],
-      "rot_coeffs" : [10, 10, 10]
+      "rot_coeffs" : [10, 10, 10],
+      "target" : "base_footprint"
     }
   }
   ],


### PR DESCRIPTION
This PR updates the Cartesian pose term info to be constructed from a transformation that is relative to an arbitrary frame that exists in the environment (rather than a transformation relative to the base frame of the kinematic chain)