### PR TITLE
Add OptStatus to TrajOptResult

### DIFF
--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -85,6 +85,7 @@ struct TRAJOPT_API TrajOptResult
   std::vector<std::string> cost_names, cnt_names;
   DblVec cost_vals, cnt_viols;
   TrajArray traj;
+  sco::OptStatus status;
   TrajOptResult(sco::OptResults& opt, TrajOptProb& prob);
 };
 

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -358,7 +358,7 @@ void generateInitTraj(TrajArray& init_traj, const ProblemConstructionInfo& pci)
 }
 
 TrajOptResult::TrajOptResult(sco::OptResults& opt, TrajOptProb& prob)
-  : cost_vals(opt.cost_vals), cnt_viols(opt.cnt_viols)
+  : cost_vals(opt.cost_vals), cnt_viols(opt.cnt_viols), status(opt.status)
 {
   for (const sco::Cost::Ptr& cost : prob.getCosts())
   {


### PR DESCRIPTION
I would like to propose the following change: add the `OptStatus` field to `TrajOptResult`. Right now, using `OptimizeProblem` is a useful convenience function that sets quite a few defaults automatically, but the result struct it returns is incomplete. Indeed, it's pretty much impossible to understand if the optimization succeeded or not based on only the trajectory, costs and constraints values.

Let me know what you think!