### PR TITLE
Use ResourceLocator instead of ResourceLocaterFn in tesseract unit tests

### DIFF
--- a/trajopt/test/cast_cost_attached_unit.cpp
+++ b/trajopt/test/cast_cost_attached_unit.cpp
@@ -45,7 +45,7 @@ public:
     boost::filesystem::path urdf_file(std::string(TRAJOPT_DIR) + "/test/data/boxbot.urdf");
     boost::filesystem::path srdf_file(std::string(TRAJOPT_DIR) + "/test/data/boxbot.srdf");
 
-    ResourceLocatorFn locator = locateResource;
+    ResourceLocator::Ptr locator = std::make_shared<SimpleResourceLocator>(locateResource);
     EXPECT_TRUE(tesseract_->init(urdf_file, srdf_file, locator));
 
     gLogLevel = util::LevelDebug;

--- a/trajopt/test/cast_cost_octomap_unit.cpp
+++ b/trajopt/test/cast_cost_octomap_unit.cpp
@@ -47,7 +47,7 @@ public:
     boost::filesystem::path urdf_file(std::string(TRAJOPT_DIR) + "/test/data/boxbot_world.urdf");
     boost::filesystem::path srdf_file(std::string(TRAJOPT_DIR) + "/test/data/boxbot.srdf");
 
-    ResourceLocatorFn locator = locateResource;
+    ResourceLocator::Ptr locator = std::make_shared<SimpleResourceLocator>(locateResource);
     EXPECT_TRUE(tesseract_->init(urdf_file, srdf_file, locator));
 
     gLogLevel = util::LevelError;

--- a/trajopt/test/cast_cost_unit.cpp
+++ b/trajopt/test/cast_cost_unit.cpp
@@ -45,7 +45,7 @@ public:
     boost::filesystem::path urdf_file(std::string(TRAJOPT_DIR) + "/test/data/boxbot.urdf");
     boost::filesystem::path srdf_file(std::string(TRAJOPT_DIR) + "/test/data/boxbot.srdf");
 
-    ResourceLocatorFn locator = locateResource;
+    ResourceLocator::Ptr locator = std::make_shared<SimpleResourceLocator>(locateResource);
     EXPECT_TRUE(tesseract_->init(urdf_file, srdf_file, locator));
 
     gLogLevel = util::LevelError;

--- a/trajopt/test/cast_cost_world_unit.cpp
+++ b/trajopt/test/cast_cost_world_unit.cpp
@@ -45,7 +45,7 @@ public:
     boost::filesystem::path urdf_file(std::string(TRAJOPT_DIR) + "/test/data/boxbot_world.urdf");
     boost::filesystem::path srdf_file(std::string(TRAJOPT_DIR) + "/test/data/boxbot.srdf");
 
-    ResourceLocatorFn locator = locateResource;
+    ResourceLocator::Ptr locator = std::make_shared<SimpleResourceLocator>(locateResource);
     EXPECT_TRUE(tesseract_->init(urdf_file, srdf_file, locator));
 
     gLogLevel = util::LevelError;

--- a/trajopt/test/interface_unit.cpp
+++ b/trajopt/test/interface_unit.cpp
@@ -38,7 +38,7 @@ public:
     boost::filesystem::path urdf_file(std::string(TRAJOPT_DIR) + "/test/data/arm_around_table.urdf");
     boost::filesystem::path srdf_file(std::string(TRAJOPT_DIR) + "/test/data/pr2.srdf");
 
-    ResourceLocatorFn locator = locateResource;
+    ResourceLocator::Ptr locator = std::make_shared<SimpleResourceLocator>(locateResource);
     EXPECT_TRUE(tesseract_->init(urdf_file, srdf_file, locator));
 
     gLogLevel = util::LevelError;

--- a/trajopt/test/joint_costs_unit.cpp
+++ b/trajopt/test/joint_costs_unit.cpp
@@ -42,7 +42,7 @@ public:
     boost::filesystem::path urdf_file(std::string(TRAJOPT_DIR) + "/test/data/arm_around_table.urdf");
     boost::filesystem::path srdf_file(std::string(TRAJOPT_DIR) + "/test/data/pr2.srdf");
 
-    ResourceLocatorFn locator = locateResource;
+    ResourceLocator::Ptr locator = std::make_shared<SimpleResourceLocator>(locateResource);
     EXPECT_TRUE(tesseract_->init(urdf_file, srdf_file, locator));
 
     gLogLevel = util::LevelError;

--- a/trajopt/test/kinematic_costs_unit.cpp
+++ b/trajopt/test/kinematic_costs_unit.cpp
@@ -42,7 +42,7 @@ public:
     boost::filesystem::path urdf_file(std::string(TRAJOPT_DIR) + "/test/data/arm_around_table.urdf");
     boost::filesystem::path srdf_file(std::string(TRAJOPT_DIR) + "/test/data/pr2.srdf");
 
-    ResourceLocatorFn locator = locateResource;
+    ResourceLocator::Ptr locator = std::make_shared<SimpleResourceLocator>(locateResource);
     EXPECT_TRUE(tesseract_->init(urdf_file, srdf_file, locator));
 
     gLogLevel = util::LevelError;

--- a/trajopt/test/planning_unit.cpp
+++ b/trajopt/test/planning_unit.cpp
@@ -43,7 +43,7 @@ public:
     boost::filesystem::path urdf_file(std::string(TRAJOPT_DIR) + "/test/data/arm_around_table.urdf");
     boost::filesystem::path srdf_file(std::string(TRAJOPT_DIR) + "/test/data/pr2.srdf");
 
-    ResourceLocatorFn locator = locateResource;
+    ResourceLocator::Ptr locator = std::make_shared<SimpleResourceLocator>(locateResource);
     EXPECT_TRUE(tesseract_->init(urdf_file, srdf_file, locator));
 
     // Create plotting tool


### PR DESCRIPTION
This pull request updates `trajopt_ros` to work with https://github.com/ros-industrial-consortium/tesseract/pull/172.