### PR TITLE
Update interface to OSQP 0.6.0

### DIFF
--- a/trajopt_sco/src/osqp_interface.cpp
+++ b/trajopt_sco/src/osqp_interface.cpp
@@ -172,7 +172,7 @@ void OSQPModel::createOrUpdateSolver()
   if (osqp_workspace_ != nullptr)
     osqp_cleanup(osqp_workspace_);
   // Setup workspace - this should be called only once
-  osqp_workspace_ = osqp_setup(&osqp_data_, &osqp_settings_);
+  osqp_setup(&osqp_workspace_, &osqp_data_, &osqp_settings_);
 }
 
 void OSQPModel::update()

--- a/trajopt_sco/src/osqp_interface.cpp
+++ b/trajopt_sco/src/osqp_interface.cpp
@@ -177,7 +177,7 @@ void OSQPModel::createOrUpdateSolver()
     osqp_cleanup(osqp_workspace_);
   // Setup workspace - this should be called only once
   auto ret = osqp_setup(&osqp_workspace_, &osqp_data_, &osqp_settings_);
-  if(ret)
+  if (ret)
   {
     throw std::runtime_error("Could not initialize OSQP: error " + std::to_string(ret));
   }


### PR DESCRIPTION
Since [version 0.6.0](https://github.com/oxfordcontrol/osqp/releases/tag/v0.6.0) OSQP's interface has changed. `osqp_setup` now returns an error code and fills in the workspace (which is now a pointer to pointer). This is the minimum change required to make this work, but I guess this PR is more a discussion:
- How should the deprecation / version change be handled?
- Properly taking into account the return code requires a number of tweaks to the interface, I'm not sure I understand the ramifications so I'd like some guidance.

