### PR TITLE
WIP: Inflate only the constraints that failed

### DIFF
--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -144,7 +144,8 @@ void ProblemConstructionInfo::readOptInfo(const Json::Value& v)
   json_marshal::childFromJson(
       v, opt_info.merit_coeff_increase_ratio, "merit_coeff_increase_ratio", opt_info.merit_coeff_increase_ratio);
   json_marshal::childFromJson(v, opt_info.max_time, "max_time", opt_info.max_time);
-  json_marshal::childFromJson(v, opt_info.merit_error_coeff, "merit_error_coeff", opt_info.merit_error_coeff);
+  json_marshal::childFromJson(v, opt_info.initial_merit_error_coeff, "initial_merit_error_coeff", opt_info.initial_merit_error_coeff);
+  json_marshal::childFromJson(v, opt_info.inflate_constraints_individually, "inflate_constraints_individually", opt_info.inflate_constraints_individually);
   json_marshal::childFromJson(v, opt_info.trust_box_size, "trust_box_size", opt_info.trust_box_size);
 }
 
@@ -380,7 +381,7 @@ TrajOptResult::Ptr OptimizeProblem(const TrajOptProb::Ptr& prob,
   param.max_iter = 40;
   param.min_approx_improve_frac = .001;
   param.improve_ratio_threshold = .2;
-  param.merit_error_coeff = 20;
+  param.initial_merit_error_coeff = 20;
   if (plotter)
     opt.addCallback(PlotCallback(*prob, plotter));
   opt.initialize(trajToDblVec(prob->GetInitTraj()));

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -144,8 +144,12 @@ void ProblemConstructionInfo::readOptInfo(const Json::Value& v)
   json_marshal::childFromJson(
       v, opt_info.merit_coeff_increase_ratio, "merit_coeff_increase_ratio", opt_info.merit_coeff_increase_ratio);
   json_marshal::childFromJson(v, opt_info.max_time, "max_time", opt_info.max_time);
-  json_marshal::childFromJson(v, opt_info.initial_merit_error_coeff, "initial_merit_error_coeff", opt_info.initial_merit_error_coeff);
-  json_marshal::childFromJson(v, opt_info.inflate_constraints_individually, "inflate_constraints_individually", opt_info.inflate_constraints_individually);
+  json_marshal::childFromJson(
+      v, opt_info.initial_merit_error_coeff, "initial_merit_error_coeff", opt_info.initial_merit_error_coeff);
+  json_marshal::childFromJson(v,
+                              opt_info.inflate_constraints_individually,
+                              "inflate_constraints_individually",
+                              opt_info.inflate_constraints_individually);
   json_marshal::childFromJson(v, opt_info.trust_box_size, "trust_box_size", opt_info.trust_box_size);
 }
 

--- a/trajopt_sco/include/trajopt_sco/optimizers.hpp
+++ b/trajopt_sco/include/trajopt_sco/optimizers.hpp
@@ -95,11 +95,15 @@ struct BasicTrustRegionSQPParameters
                               // this ratio
   double cnt_tolerance;       // after convergence of penalty subproblem, if
   // constraint violation is less than this, we're done
-  double max_merit_coeff_increases;   // number of times that we jack up penalty
-                                      // coefficient
+  /** @brief Max number of times that the constraints' cost will be increased */
+  double max_merit_coeff_increases;
+
   double merit_coeff_increase_ratio;  // ratio that we increate coeff each time
   double max_time;                    // not yet implemented
-  double merit_error_coeff;           // initial penalty coefficient
+  /** @brief Initial coefficient that is used to scale the constraints. The total constaint cost is constaint_value * coeff * merit_coeff */
+  double initial_merit_error_coeff;
+  /** @brief If true, merit coeffs will only be inflated for the constaints that failed. This can help when there are lots of constaints*/
+  bool inflate_constraints_individually;
   double trust_box_size;              // current size of trust region (component-wise)
 
   bool log_results;     // Log results to file
@@ -159,7 +163,7 @@ struct BasicTrustRegionSQPResults
    */
   double merit_improve_ratio;
   /** @brief This is the penalty applied to the constraints for this iteration */
-  double merit_error_coeff;
+  std::vector<double> merit_error_coeffs;
   /** @brief Variable names */
   const std::vector<std::string> var_names;
   /** @brief Cost Names */
@@ -189,7 +193,7 @@ struct BasicTrustRegionSQPResults
               const std::vector<ConvexObjective::Ptr>& cnt_cost_models,
               const std::vector<Constraint::Ptr>& constraints,
               const std::vector<Cost::Ptr>& costs,
-              double merit_error_coeff);
+              std::vector<double> merit_error_coeffs);
 
   /** @brief Print current results to the terminal */
   void print() const;

--- a/trajopt_sco/include/trajopt_sco/optimizers.hpp
+++ b/trajopt_sco/include/trajopt_sco/optimizers.hpp
@@ -100,11 +100,13 @@ struct BasicTrustRegionSQPParameters
 
   double merit_coeff_increase_ratio;  // ratio that we increate coeff each time
   double max_time;                    // not yet implemented
-  /** @brief Initial coefficient that is used to scale the constraints. The total constaint cost is constaint_value * coeff * merit_coeff */
+  /** @brief Initial coefficient that is used to scale the constraints. The total constaint cost is constaint_value *
+   * coeff * merit_coeff */
   double initial_merit_error_coeff;
-  /** @brief If true, merit coeffs will only be inflated for the constaints that failed. This can help when there are lots of constaints*/
+  /** @brief If true, merit coeffs will only be inflated for the constaints that failed. This can help when there are
+   * lots of constaints*/
   bool inflate_constraints_individually;
-  double trust_box_size;              // current size of trust region (component-wise)
+  double trust_box_size;  // current size of trust region (component-wise)
 
   bool log_results;     // Log results to file
   std::string log_dir;  // Directory to store log results (Default: /tmp)

--- a/trajopt_sco/src/optimizers.cpp
+++ b/trajopt_sco/src/optimizers.cpp
@@ -292,23 +292,25 @@ void BasicTrustRegionSQPResults::update(const OptResults& prev_opt_results,
 
 void BasicTrustRegionSQPResults::print() const
 {
-  std::printf("%15s | %10s | %10s | %10s | %10s\n", "", "oldexact", "dapprox", "dexact", "ratio");
-  std::printf("%15s | %10s---%10s---%10s---%10s\n", "COSTS", "----------", "----------", "----------", "----------");
+  std::printf("%15s | %10s | %10s | %10s | %10s | %10s\n", "", "oldexact", "new_exact", "dapprox", "dexact", "ratio");
+  std::printf("%15s | %10s---%10s---%10s---%10s---%10s\n", "COSTS", "----------", "----------", "----------", "----------", "----------");
   for (size_t i = 0; i < old_cost_vals.size(); ++i)
   {
     double approx_improve = old_cost_vals[i] - model_cost_vals[i];
     double exact_improve = old_cost_vals[i] - new_cost_vals[i];
     if (fabs(approx_improve) > 1e-8)
-      std::printf("%15s | %10.3e | %10.3e | %10.3e | %10.3e\n",
+      std::printf("%15s | %10.3e | %10.3e | %10.3e | %10.3e | %10.3e\n",
                   cost_names[i].c_str(),
                   old_cost_vals[i],
+                  new_cost_vals[i],
                   approx_improve,
                   exact_improve,
                   exact_improve / approx_improve);
     else
-      std::printf("%15s | %10.3e | %10.3e | %10.3e | %10s\n",
+      std::printf("%15s | %10.3e | %10.3e | %10.3e | %10.3e | %10s\n",
                   cost_names[i].c_str(),
                   old_cost_vals[i],
+                  new_cost_vals[i],
                   approx_improve,
                   exact_improve,
                   "  ------  ");
@@ -316,8 +318,9 @@ void BasicTrustRegionSQPResults::print() const
 
   if (!cnt_names.empty())
   {
-    std::printf("%15s | %10s---%10s---%10s---%10s\n",
+    std::printf("%15s | %10s---%10s---%10s---%10s---%10s\n",
                 "CONSTRAINTS",
+                "----------",
                 "----------",
                 "----------",
                 "----------",
@@ -328,25 +331,28 @@ void BasicTrustRegionSQPResults::print() const
       double approx_improve = old_cnt_viols[i] - model_cnt_viols[i];
       double exact_improve = old_cnt_viols[i] - new_cnt_viols[i];
       if (fabs(approx_improve) > 1e-8)
-        std::printf("%15s | %10.3e | %10.3e | %10.3e | %10.3e\n",
+        std::printf("%15s | %10.3e | %10.3e | %10.3e | %10.3e | %10.3e\n",
                     cnt_names[i].c_str(),
                     merit_error_coeff * old_cnt_viols[i],
+                    merit_error_coeff * new_cnt_viols[i],
                     merit_error_coeff * approx_improve,
                     merit_error_coeff * exact_improve,
                     exact_improve / approx_improve);
       else
-        std::printf("%15s | %10.3e | %10.3e | %10.3e | %10s\n",
+        std::printf("%15s | %10.3e | %10.3e | %10.3e | %10.3e | %10s\n",
                     cnt_names[i].c_str(),
                     merit_error_coeff * old_cnt_viols[i],
+                    merit_error_coeff * new_cnt_viols[i],
                     merit_error_coeff * approx_improve,
                     merit_error_coeff * exact_improve,
                     "  ------  ");
     }
   }
 
-  std::printf("%15s | %10.3e | %10.3e | %10.3e | %10.3e\n",
+  std::printf("%15s | %10.3e | %10.3e | %10.3e | %10.3e | %10.3e\n",
               "TOTAL",
               old_merit,
+              new_merit,
               approx_merit_improve,
               exact_merit_improve,
               merit_improve_ratio);
@@ -355,12 +361,13 @@ void BasicTrustRegionSQPResults::print() const
 void BasicTrustRegionSQPResults::writeSolver(std::FILE* stream, bool header) const
 {
   if (header)
-    std::fprintf(stream, "%s,%s,%s,%s,%s\n", "DESCRIPTION", "oldexact", "dapprox", "dexact", "ratio");
+    std::fprintf(stream, "%s,%s,%s,%s,%s,%s\n", "DESCRIPTION", "oldexact", "new_exact", "dapprox", "dexact", "ratio");
 
   std::fprintf(stream,
-               "%s,%10.3e,%10.3e,%10.3e,%10.3e\n",
+               "%s,%10.3e,%10.3e,%10.3e,%10.3e,%10.3e\n",
                "Solver",
                old_merit,
+               new_merit,
                approx_merit_improve,
                exact_merit_improve,
                merit_improve_ratio);

--- a/trajopt_sco/src/optimizers.cpp
+++ b/trajopt_sco/src/optimizers.cpp
@@ -117,7 +117,7 @@ static std::vector<std::string> getVarNames(const VarVector& vars)
 
 // todo: use different coeffs for each constraint
 std::vector<ConvexObjective::Ptr> cntsToCosts(const std::vector<ConvexConstraints::Ptr>& cnts,
-                                              const std::vector<double> err_coeffs,
+                                              const std::vector<double>& err_coeffs,
                                               Model* model)
 {
   assert(cnts.size() == err_coeffs.size());

--- a/trajopt_sco/src/optimizers.cpp
+++ b/trajopt_sco/src/optimizers.cpp
@@ -269,8 +269,7 @@ void BasicTrustRegionSQPResults::update(const OptResults& prev_opt_results,
     DblVec cnt_costs1 = evaluateModelCosts(cnt_cost_models, model_var_vals);
     DblVec cnt_costs2 = model_cnt_viols;
     for (unsigned i = 0; i < cnt_costs2.size(); ++i)
-      for (auto& cnt_cost2 : cnt_costs2)
-        cnt_cost2 *= merit_error_coeffs[i];
+      cnt_costs2[i] *= merit_error_coeffs[i];
     LOG_DEBUG("SHOULD BE ALMOST THE SAME: %s ?= %s", CSTR(cnt_costs1), CSTR(cnt_costs2));
     // not exactly the same because cnt_costs1 is based on aux variables,
     // but they might not be at EXACTLY the right value

--- a/trajopt_sco/test/small-problems-unit.cpp
+++ b/trajopt_sco/test/small-problems-unit.cpp
@@ -103,7 +103,7 @@ void testProblem(ScalarOfVector::Ptr f,
   params.max_iter = 1000;
   params.min_trust_box_size = 1e-5;
   params.min_approx_improve = 1e-10;
-  params.merit_error_coeff = 1;
+  params.initial_merit_error_coeff = 1;
 
   solver.initialize(init);
   OptStatus status = solver.optimize();


### PR DESCRIPTION
This pull request changes the way that constraints are inflated. Rather than inflating constraints uniformly if they are not satisfied when the optimization converges, this inflates only the constraints that failed. This could allow the optimization to get out of local minima more easily. Currently, local minima that are caused by competing constraints are still local minima after they are uniformly scaled. 

This is WIP because it depends on the clang-tidy pull request. It should also probably be tested again before merging as it has not been tested since being rebased.