### PR TITLE
Enable continuous collision checking for moving to moving objects

### DIFF
--- a/trajopt/include/trajopt/collision_terms.hpp
+++ b/trajopt/include/trajopt/collision_terms.hpp
@@ -18,12 +18,16 @@ struct CollisionEvaluator
                      tesseract_environment::Environment::ConstPtr env,
                      tesseract_environment::AdjacencyMap::ConstPtr adjacency_map,
                      const Eigen::Isometry3d& world_to_base,
-                     SafetyMarginData::ConstPtr safety_margin_data)
+                     SafetyMarginData::ConstPtr safety_margin_data,
+                     tesseract_collision::ContactTestType contact_test_type,
+                     double longest_valid_segment_length)
     : manip_(std::move(manip))
     , env_(std::move(env))
     , adjacency_map_(std::move(adjacency_map))
     , world_to_base_(world_to_base)
     , safety_margin_data_(std::move(safety_margin_data))
+    , contact_test_type_(contact_test_type)
+    , longest_valid_segment_length_(longest_valid_segment_length)
   {
   }
   virtual ~CollisionEvaluator() = default;
@@ -48,6 +52,8 @@ protected:
   tesseract_environment::AdjacencyMap::ConstPtr adjacency_map_;
   Eigen::Isometry3d world_to_base_;
   SafetyMarginData::ConstPtr safety_margin_data_;
+  tesseract_collision::ContactTestType contact_test_type_;
+  double longest_valid_segment_length_;
 
 private:
   CollisionEvaluator() = default;
@@ -61,6 +67,7 @@ public:
                                    tesseract_environment::AdjacencyMap::ConstPtr adjacency_map,
                                    const Eigen::Isometry3d& world_to_base,
                                    SafetyMarginData::ConstPtr safety_margin_data,
+                                   tesseract_collision::ContactTestType contact_test_type,
                                    sco::VarVector vars);
   /**
   @brief linearize all contact distances in terms of robot dofs
@@ -81,6 +88,7 @@ public:
 private:
   sco::VarVector m_vars;
   tesseract_collision::DiscreteContactManager::Ptr contact_manager_;
+  tesseract_environment::StateSolver::Ptr state_solver_;
 };
 
 struct CastCollisionEvaluator : public CollisionEvaluator
@@ -91,6 +99,8 @@ public:
                          tesseract_environment::AdjacencyMap::ConstPtr adjacency_map,
                          const Eigen::Isometry3d& world_to_base,
                          SafetyMarginData::ConstPtr safety_margin_data,
+                         tesseract_collision::ContactTestType contact_test_type,
+                         double longest_valid_segment_length,
                          sco::VarVector vars0,
                          sco::VarVector vars1);
   void CalcDistExpressions(const DblVec& x, sco::AffExprVector& exprs) override;
@@ -103,6 +113,7 @@ private:
   sco::VarVector m_vars0;
   sco::VarVector m_vars1;
   tesseract_collision::ContinuousContactManager::Ptr contact_manager_;
+  tesseract_environment::StateSolver::Ptr state_solver_;
 };
 
 class TRAJOPT_API CollisionCost : public sco::Cost, public Plotter
@@ -114,6 +125,7 @@ public:
                 tesseract_environment::AdjacencyMap::ConstPtr adjacency_map,
                 const Eigen::Isometry3d& world_to_base,
                 SafetyMarginData::ConstPtr safety_margin_data,
+                tesseract_collision::ContactTestType contact_test_type,
                 sco::VarVector vars);
   /* constructor for cast cost */
   CollisionCost(tesseract_kinematics::ForwardKinematics::ConstPtr manip,
@@ -121,6 +133,8 @@ public:
                 tesseract_environment::AdjacencyMap::ConstPtr adjacency_map,
                 const Eigen::Isometry3d& world_to_base,
                 SafetyMarginData::ConstPtr safety_margin_data,
+                tesseract_collision::ContactTestType contact_test_type,
+                double longest_valid_segment_length,
                 sco::VarVector vars0,
                 sco::VarVector vars1);
   sco::ConvexObjective::Ptr convex(const DblVec& x, sco::Model* model) override;
@@ -141,6 +155,7 @@ public:
                       tesseract_environment::AdjacencyMap::ConstPtr adjacency_map,
                       const Eigen::Isometry3d& world_to_base,
                       SafetyMarginData::ConstPtr safety_margin_data,
+                      tesseract_collision::ContactTestType contact_test_type,
                       sco::VarVector vars);
   /* constructor for cast cost */
   CollisionConstraint(tesseract_kinematics::ForwardKinematics::ConstPtr manip,
@@ -148,6 +163,8 @@ public:
                       tesseract_environment::AdjacencyMap::ConstPtr adjacency_map,
                       const Eigen::Isometry3d& world_to_base,
                       SafetyMarginData::ConstPtr safety_margin_data,
+                      tesseract_collision::ContactTestType contact_test_type,
+                      double longest_valid_segment_length,
                       sco::VarVector vars0,
                       sco::VarVector vars1);
   sco::ConvexConstraints::Ptr convex(const DblVec& x, sco::Model* model) override;

--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -547,9 +547,16 @@ struct CollisionTermInfo : public TermInfo
   /** @brief Indicate if continuous collision checking should be used. */
   bool continuous;
 
-  /** @brief for continuous-time penalty, use swept-shape between timesteps t and t+gap */
-  /** @brief (gap=1 by default) */
-  int gap;
+  /** @brief Set the resolution at which state validity needs to be verified in order for a motion between two states
+   * to be considered valid. If norm(state1 - state0) > longest_valid_segment_length.
+   *
+   * Note: This gets converted to longest_valid_segment_fraction.
+   *       longest_valid_segment_fraction = longest_valid_segment_length / state_space.getMaximumExtent()
+   */
+  double longest_valid_segment_length = 0.5;
+
+  /** @brief Set the contact test type that should be used. */
+  tesseract_collision::ContactTestType contact_test_type = tesseract_collision::ContactTestType::ALL;
 
   /** @brief Contains distance penalization data: Safety Margin, Coeff used during */
   /** @brief optimization, etc. */

--- a/trajopt/src/collision_terms.cpp
+++ b/trajopt/src/collision_terms.cpp
@@ -195,7 +195,7 @@ void CollisionsToDistanceExpressions(sco::AffExprVector& exprs,
       // point to the new ref point.
       double scale = 1;
       Eigen::Isometry3d link_transform = res.transform[0];
-      if (res.cc_type[0] != tesseract_collision::ContinouseCollisionType::CCType_None)
+      if (res.cc_type[0] != tesseract_collision::ContinuousCollisionType::CCType_None)
       {
         assert(res.cc_time[0] >= 0.0 && res.cc_time[0] <= 1.0);
         scale = (isTimestep1) ? res.cc_time[0] : (1 - res.cc_time[0]);
@@ -235,7 +235,7 @@ void CollisionsToDistanceExpressions(sco::AffExprVector& exprs,
       // point to the new ref point.
       double scale = 1;
       Eigen::Isometry3d link_transform = res.transform[1];
-      if (res.cc_type[1] != tesseract_collision::ContinouseCollisionType::CCType_None)
+      if (res.cc_type[1] != tesseract_collision::ContinuousCollisionType::CCType_None)
       {
         assert(res.cc_time[1] >= 0.0 && res.cc_time[1] <= 1.0);
         scale = (isTimestep1) ? res.cc_time[1] : (1 - res.cc_time[1]);
@@ -496,10 +496,10 @@ void CastCollisionEvaluator::CalcCollisions(const DblVec& x, tesseract_collision
           double m = std::numeric_limits<double>::max();
           for (auto& r : pair.second)
           {
-            if (r.cc_type[0] != tesseract_collision::ContinouseCollisionType::CCType_None)
+            if (r.cc_type[0] != tesseract_collision::ContinuousCollisionType::CCType_None)
               r.cc_time[0] = (static_cast<double>(i) * dt) + (dt * r.cc_time[0]);
 
-            if (r.cc_type[1] != tesseract_collision::ContinouseCollisionType::CCType_None)
+            if (r.cc_type[1] != tesseract_collision::ContinuousCollisionType::CCType_None)
               r.cc_time[1] = (static_cast<double>(i) * dt) + (dt * r.cc_time[1]);
 
             if (r.distance < m)

--- a/trajopt/test/cast_cost_attached_unit.cpp
+++ b/trajopt/test/cast_cost_attached_unit.cpp
@@ -74,6 +74,7 @@ public:
 
     tesseract_->getEnvironment()->addLink(box_attached_link, box_attached_joint);
     tesseract_->getEnvironment()->setLinkCollisionEnabled("box_attached", false);
+    tesseract_->getEnvironment()->addAllowedCollision("box_attached", "boxbot_link", "Adjacent");
 
     Link box_attached2_link("box_attached2");
     box_attached2_link.visual.push_back(visual);
@@ -86,6 +87,7 @@ public:
 
     tesseract_->getEnvironment()->addLink(box_attached2_link, box_attached2_joint);
     tesseract_->getEnvironment()->setLinkCollisionEnabled("box_attached2", false);
+    tesseract_->getEnvironment()->addAllowedCollision("box_attached2", "boxbot_link", "Adjacent");
   }
 };
 

--- a/trajopt/test/cast_cost_attached_unit.cpp
+++ b/trajopt/test/cast_cost_attached_unit.cpp
@@ -54,12 +54,12 @@ public:
     //    plotter_.reset(new tesseract_ros::ROSBasicPlotting(env_));
 
     // Next add objects that can be attached/detached to the scene
-    Box::Ptr box(new Box(0.25, 0.25, 0.25));
-    Visual::Ptr visual(new Visual());
+    auto box = std::make_shared<Box>(0.25, 0.25, 0.25);
+    auto visual = std::make_shared<Visual>();
     visual->geometry = box;
     visual->origin = Eigen::Isometry3d::Identity();
 
-    Collision::Ptr collision(new Collision());
+    auto collision = std::make_shared<Collision>();
     collision->geometry = box;
     collision->origin = Eigen::Isometry3d::Identity();
 

--- a/trajopt/test/cast_cost_world_unit.cpp
+++ b/trajopt/test/cast_cost_world_unit.cpp
@@ -54,13 +54,13 @@ public:
     //    plotter_.reset(new tesseract_ros::ROSBasicPlotting(env_));
 
     // Next add objects that can be attached/detached to the scene
-    Box::Ptr box(new Box(1.0, 1.0, 1.0));
+    auto box = std::make_shared<Box>(1.0, 1.0, 1.0);
 
-    Visual::Ptr visual(new Visual());
+    auto visual = std::make_shared<Visual>();
     visual->geometry = box;
     visual->origin = Eigen::Isometry3d::Identity();
 
-    Collision::Ptr collision(new Collision());
+    auto collision = std::make_shared<Collision>();
     collision->geometry = box;
     collision->origin = Eigen::Isometry3d::Identity();
 


### PR DESCRIPTION
This enables avoiding moving objects to moving objects when continuous collision checking is enabled.