### PR TITLE
Remove the additional 0.04 added to contact distance threshold

### DIFF
--- a/trajopt/src/collision_terms.cpp
+++ b/trajopt/src/collision_terms.cpp
@@ -330,8 +330,7 @@ SingleTimestepCollisionEvaluator::SingleTimestepCollisionEvaluator(
 {
   contact_manager_ = env_->getDiscreteContactManager();
   contact_manager_->setActiveCollisionObjects(adjacency_map_->getActiveLinkNames());
-  contact_manager_->setContactDistanceThreshold(safety_margin_data_->getMaxSafetyMargin() +
-                                                0.04);  // The original implementation added a margin of 0.04;
+  contact_manager_->setContactDistanceThreshold(safety_margin_data_->getMaxSafetyMargin());
   state_solver_ = env_->getStateSolver();
 }
 
@@ -443,8 +442,7 @@ CastCollisionEvaluator::CastCollisionEvaluator(tesseract_kinematics::ForwardKine
 {
   contact_manager_ = env_->getContinuousContactManager();
   contact_manager_->setActiveCollisionObjects(adjacency_map_->getActiveLinkNames());
-  contact_manager_->setContactDistanceThreshold(safety_margin_data_->getMaxSafetyMargin() +
-                                                0.04);  // The original implementation added a margin of 0.04;
+  contact_manager_->setContactDistanceThreshold(safety_margin_data_->getMaxSafetyMargin());
 
   state_solver_ = env_->getStateSolver();
 }


### PR DESCRIPTION
Reading through the old repository this was carried over because Bullet added this margin to the contact shapes. This makes since in the case of solving for the exact point of contact but is not required just for contact checking so removing. This should speed up the optimization for chases where you are always in close proximity.