### PR TITLE
Update casted collision evaluator to handle fixed start and end states

### DIFF
--- a/trajopt/include/trajopt/collision_terms.hpp
+++ b/trajopt/include/trajopt/collision_terms.hpp
@@ -8,13 +8,23 @@
 
 namespace trajopt
 {
-enum class CollisionEvaluatorType
+/**
+ * @brief This contains the different types of expression evaluators used when performing continuous collision checking.
+ */
+enum class CollisionExpressionEvaluatorType
 {
   START_FREE_END_FREE = 0,  /**< @brief Both start and end state variables are free to be adjusted */
   START_FREE_END_FIXED = 1, /**< @brief Only start state variables are free to be adjusted */
   START_FIXED_END_FREE = 2  /**< @brief Only end state variables are free to be adjusted */
 };
 
+/**
+ * @brief Base class for collision evaluators containing function that are commonly used between them.
+ *
+ * This class also facilitates the caching of the contact results to prevent collision checking from being called
+ * multiple times throughout the optimization.
+ *
+ */
 struct CollisionEvaluator
 {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -27,29 +37,58 @@ struct CollisionEvaluator
                      const Eigen::Isometry3d& world_to_base,
                      SafetyMarginData::ConstPtr safety_margin_data,
                      tesseract_collision::ContactTestType contact_test_type,
-                     double longest_valid_segment_length)
-    : manip_(std::move(manip))
-    , env_(std::move(env))
-    , adjacency_map_(std::move(adjacency_map))
-    , world_to_base_(world_to_base)
-    , safety_margin_data_(std::move(safety_margin_data))
-    , contact_test_type_(contact_test_type)
-    , longest_valid_segment_length_(longest_valid_segment_length)
-  {
-  }
+                     double longest_valid_segment_length);
   virtual ~CollisionEvaluator() = default;
   CollisionEvaluator(const CollisionEvaluator&) = default;
   CollisionEvaluator& operator=(const CollisionEvaluator&) = default;
   CollisionEvaluator(CollisionEvaluator&&) = default;
   CollisionEvaluator& operator=(CollisionEvaluator&&) = default;
 
+  /**
+   * @brief This function calls GetCollisionsCached and stores the distances in a vector
+   * @param x Optimizer variables
+   * @param dists Returned distance values
+   */
+  virtual void CalcDists(const DblVec& x, DblVec& dists);
+
+  /**
+   * @brief Convert the contact information into an affine expression
+   * @param x Optimizer variables
+   * @param exprs Returned affine expression representation of the contact information
+   */
   virtual void CalcDistExpressions(const DblVec& x, sco::AffExprVector& exprs) = 0;
-  virtual void CalcDists(const DblVec& x, DblVec& exprs) = 0;
+
+  /**
+   * @brief Given optimizer parameters calculate the collision results for this evaluator
+   * @param x Optimizer variables
+   * @param dist_results Contact results
+   */
   virtual void CalcCollisions(const DblVec& x, tesseract_collision::ContactResultVector& dist_results) = 0;
+
+  /**
+   * @brief This function checks to see if results are cached for input variable x. If not it calls CalcCollisions and
+   * caches the results with x as the key.
+   * @param x Optimizer variables
+   */
   void GetCollisionsCached(const DblVec& x, tesseract_collision::ContactResultVector&);
+
+  /**
+   * @brief Plot the collision evaluator results
+   * @param plotter Plotter
+   * @param x Optimizer variables
+   */
   virtual void Plot(const tesseract_visualization::Visualization::Ptr& plotter, const DblVec& x) = 0;
+
+  /**
+   * @brief Get the specific optimizer variables associated with this evaluator.
+   * @return Evaluators variables
+   */
   virtual sco::VarVector GetVars() = 0;
 
+  /**
+   * @brief Get the safety margin information.
+   * @return Safety margin information
+   */
   const SafetyMarginData::ConstPtr getSafetyMarginData() const { return safety_margin_data_; }
   Cache<size_t, tesseract_collision::ContactResultVector, 10> m_cache;
 
@@ -61,11 +100,57 @@ protected:
   SafetyMarginData::ConstPtr safety_margin_data_;
   tesseract_collision::ContactTestType contact_test_type_;
   double longest_valid_segment_length_;
+  tesseract_environment::StateSolver::Ptr state_solver_;
+  sco::VarVector vars0_;
+  sco::VarVector vars1_;
+  CollisionExpressionEvaluatorType evaluator_type_;
+
+  /**
+   * @brief Calculate the distance expressions when the start is free but the end is fixed
+   * @param x The current values
+   * @param exprs The returned expression
+   */
+  void CalcDistExpressionsStartFree(const DblVec& x, sco::AffExprVector& exprs);
+
+  /**
+   * @brief Calculate the distance expressions when the end is free but the start is fixed
+   * @param x The current values
+   * @param exprs The returned expression
+   */
+  void CalcDistExpressionsEndFree(const DblVec& x, sco::AffExprVector& exprs);
+
+  /**
+   * @brief Calculate the distance expressions when the start and end are free
+   * @param x The current values
+   * @param exprs The returned expression
+   */
+  void CalcDistExpressionsBothFree(const DblVec& x, sco::AffExprVector& exprs);
+
+  /**
+   * @brief This takes contacts results at each interpolated timestep and creates a single contact results map.
+   * This also updates the cc_time and cc_type for the contact results
+   * @param contacts_vector Contact results map at each interpolated timestep
+   * @param contact_results The merged contact results map
+   */
+  void processInterpolatedCollisionResults(std::vector<tesseract_collision::ContactResultMap>& contacts_vector,
+                                           tesseract_collision::ContactResultMap& contact_results) const;
+
+  /**
+   * @brief Remove any results that are invalid.
+   * Invalid state are contacts that occur at fixed states or have distances outside the threshold.
+   * @param contact_results Contact results vector to process.
+   */
+  void removeInvalidContactResults(tesseract_collision::ContactResultVector& contact_results,
+                                   const Eigen::Vector2d& pair_data) const;
 
 private:
   CollisionEvaluator() = default;
 };
 
+/**
+ * @brief This collision evaluator only operates on a single state in the trajectory and does not check for collisions
+ * between states.
+ */
 struct SingleTimestepCollisionEvaluator : public CollisionEvaluator
 {
 public:
@@ -84,20 +169,18 @@ public:
   function
   */
   void CalcDistExpressions(const DblVec& x, sco::AffExprVector& exprs) override;
-  /**
-   * Same as CalcDistExpressions, but just the distances--not the expressions
-   */
-  void CalcDists(const DblVec& x, DblVec& dists) override;
   void CalcCollisions(const DblVec& x, tesseract_collision::ContactResultVector& dist_results) override;
   void Plot(const tesseract_visualization::Visualization::Ptr& plotter, const DblVec& x) override;
-  sco::VarVector GetVars() override { return m_vars; }
+  sco::VarVector GetVars() override { return vars0_; }
 
 private:
-  sco::VarVector m_vars;
   tesseract_collision::DiscreteContactManager::Ptr contact_manager_;
-  tesseract_environment::StateSolver::Ptr state_solver_;
 };
 
+/**
+ * @brief This collision evaluator operates on two states and checks for collision between the two states using a
+ * casted collision objects between to intermediate interpolated states.
+ */
 struct CastCollisionEvaluator : public CollisionEvaluator
 {
 public:
@@ -110,41 +193,42 @@ public:
                          double longest_valid_segment_length,
                          sco::VarVector vars0,
                          sco::VarVector vars1,
-                         CollisionEvaluatorType type);
+                         CollisionExpressionEvaluatorType type);
   void CalcDistExpressions(const DblVec& x, sco::AffExprVector& exprs) override;
-  void CalcDists(const DblVec& x, DblVec& exprs) override;
   void CalcCollisions(const DblVec& x, tesseract_collision::ContactResultVector& dist_results) override;
   void Plot(const tesseract_visualization::Visualization::Ptr& plotter, const DblVec& x) override;
   sco::VarVector GetVars() override { return concat(vars0_, vars1_); }
 
 private:
-  sco::VarVector vars0_;
-  sco::VarVector vars1_;
-  CollisionEvaluatorType type_;
   tesseract_collision::ContinuousContactManager::Ptr contact_manager_;
-  tesseract_environment::StateSolver::Ptr state_solver_;
   std::function<void(const DblVec&, sco::AffExprVector&)> fn_;
+};
 
-  /**
-   * @brief Calculate the distance expressions when the start is free but the end is fixed
-   * @param x The current values
-   * @param exprs The returned expression
-   */
-  void CalcDistExpressionsStartFree(const DblVec& x, sco::AffExprVector& exprs);
+/**
+ * @brief This collision evaluator operates on two states and checks for collision between the two states using a
+ * descrete collision objects at each intermediate interpolated states.
+ */
+struct DiscreteCollisionEvaluator : public CollisionEvaluator
+{
+public:
+  DiscreteCollisionEvaluator(tesseract_kinematics::ForwardKinematics::ConstPtr manip,
+                             tesseract_environment::Environment::ConstPtr env,
+                             tesseract_environment::AdjacencyMap::ConstPtr adjacency_map,
+                             const Eigen::Isometry3d& world_to_base,
+                             SafetyMarginData::ConstPtr safety_margin_data,
+                             tesseract_collision::ContactTestType contact_test_type,
+                             double longest_valid_segment_length,
+                             sco::VarVector vars0,
+                             sco::VarVector vars1,
+                             CollisionExpressionEvaluatorType type);
+  void CalcDistExpressions(const DblVec& x, sco::AffExprVector& exprs) override;
+  void CalcCollisions(const DblVec& x, tesseract_collision::ContactResultVector& dist_results) override;
+  void Plot(const tesseract_visualization::Visualization::Ptr& plotter, const DblVec& x) override;
+  sco::VarVector GetVars() override { return concat(vars0_, vars1_); }
 
-  /**
-   * @brief Calculate the distance expressions when the end is free but the start is fixed
-   * @param x The current values
-   * @param exprs The returned expression
-   */
-  void CalcDistExpressionsEndFree(const DblVec& x, sco::AffExprVector& exprs);
-
-  /**
-   * @brief Calculate the distance expressions when the start and end is free
-   * @param x The current values
-   * @param exprs The returned expression
-   */
-  void CalcDistExpressionsBothFree(const DblVec& x, sco::AffExprVector& exprs);
+private:
+  tesseract_collision::DiscreteContactManager::Ptr contact_manager_;
+  std::function<void(const DblVec&, sco::AffExprVector&)> fn_;
 };
 
 class TRAJOPT_API CollisionCost : public sco::Cost, public Plotter
@@ -158,7 +242,7 @@ public:
                 SafetyMarginData::ConstPtr safety_margin_data,
                 tesseract_collision::ContactTestType contact_test_type,
                 sco::VarVector vars);
-  /* constructor for cast cost */
+  /* constructor for discrete continuous and cast continuous cost */
   CollisionCost(tesseract_kinematics::ForwardKinematics::ConstPtr manip,
                 tesseract_environment::Environment::ConstPtr env,
                 tesseract_environment::AdjacencyMap::ConstPtr adjacency_map,
@@ -168,7 +252,8 @@ public:
                 double longest_valid_segment_length,
                 sco::VarVector vars0,
                 sco::VarVector vars1,
-                CollisionEvaluatorType type);
+                CollisionExpressionEvaluatorType type,
+                bool discrete);
   sco::ConvexObjective::Ptr convex(const DblVec& x, sco::Model* model) override;
   double value(const DblVec&) override;
   void Plot(const tesseract_visualization::Visualization::Ptr& plotter, const DblVec& x) override;
@@ -189,7 +274,7 @@ public:
                       SafetyMarginData::ConstPtr safety_margin_data,
                       tesseract_collision::ContactTestType contact_test_type,
                       sco::VarVector vars);
-  /* constructor for cast cost */
+  /* constructor for discrete continuous and cast continuous cost */
   CollisionConstraint(tesseract_kinematics::ForwardKinematics::ConstPtr manip,
                       tesseract_environment::Environment::ConstPtr env,
                       tesseract_environment::AdjacencyMap::ConstPtr adjacency_map,
@@ -199,7 +284,8 @@ public:
                       double longest_valid_segment_length,
                       sco::VarVector vars0,
                       sco::VarVector vars1,
-                      CollisionEvaluatorType type);
+                      CollisionExpressionEvaluatorType type,
+                      bool discrete);
   sco::ConvexConstraints::Ptr convex(const DblVec& x, sco::Model* model) override;
   DblVec value(const DblVec&) override;
   void Plot(const DblVec& x);

--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -530,6 +530,13 @@ struct JointJerkTermInfo : public TermInfo
   JointJerkTermInfo() : TermInfo(TT_COST | TT_CNT) {}
 };
 
+enum class CollisionEvaluatorType
+{
+  SINGLE_TIMESTEP = 0,
+  DISCRETE_CONTINUOUS = 1,
+  CAST_CONTINUOUS = 2,
+};
+
 /**
 \brief %Collision penalty
 
@@ -547,8 +554,8 @@ struct CollisionTermInfo : public TermInfo
   /** @brief first_step and last_step are inclusive */
   int first_step, last_step;
 
-  /** @brief Indicate if continuous collision checking should be used. */
-  bool continuous;
+  /** @brief Indicate the type of collision checking that should be used. */
+  CollisionEvaluatorType evaluator_type;
 
   /** @brief Indicated if a step is fixed and its variables cannot be changed */
   std::vector<int> fixed_steps;

--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -245,6 +245,9 @@ struct UserDefinedTermInfo : public TermInfo
   /** @brief Timesteps over which to apply term */
   int first_step, last_step;
 
+  /** @brief Indicated if a step is fixed and its variables cannot be changed */
+  std::vector<int> fixed_steps;
+
   /** @brief The user defined error function */
   sco::VectorOfVector::func error_function;
 
@@ -546,6 +549,9 @@ struct CollisionTermInfo : public TermInfo
 
   /** @brief Indicate if continuous collision checking should be used. */
   bool continuous;
+
+  /** @brief Indicated if a step is fixed and its variables cannot be changed */
+  std::vector<int> fixed_steps;
 
   /** @brief Set the resolution at which state validity needs to be verified in order for a motion between two states
    * to be considered valid. If norm(state1 - state0) > longest_valid_segment_length.

--- a/trajopt/include/trajopt/trajectory_costs.hpp
+++ b/trajopt/include/trajopt/trajectory_costs.hpp
@@ -14,7 +14,11 @@ class TRAJOPT_API JointPosEqCost : public sco::Cost
 {
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
-  JointPosEqCost(VarArray vars, Eigen::VectorXd coeffs, Eigen::VectorXd targets, int& first_step, int& last_step);
+  JointPosEqCost(VarArray vars,
+                 const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                 const Eigen::Ref<const Eigen::VectorXd>& targets,
+                 int first_step,
+                 int last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   sco::ConvexObjective::Ptr convex(const DblVec& x, sco::Model* model) override;
   /** @brief Numerically evaluate cost given the vector of values */
@@ -45,12 +49,12 @@ class TRAJOPT_API JointPosIneqCost : public sco::Cost
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
   JointPosIneqCost(VarArray vars,
-                   Eigen::VectorXd coeffs,
-                   Eigen::VectorXd targets,
-                   Eigen::VectorXd upper_limits,
-                   Eigen::VectorXd lower_limits,
-                   int& first_step,
-                   int& last_step);
+                   const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                   const Eigen::Ref<const Eigen::VectorXd>& targets,
+                   const Eigen::Ref<const Eigen::VectorXd>& upper_limits,
+                   const Eigen::Ref<const Eigen::VectorXd>& lower_limits,
+                   int first_step,
+                   int last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   sco::ConvexObjective::Ptr convex(const DblVec& x, sco::Model* model) override;
   /** @brief Numerically evaluate cost given the vector of values */
@@ -80,7 +84,11 @@ class TRAJOPT_API JointPosEqConstraint : public sco::EqConstraint
 {
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
-  JointPosEqConstraint(VarArray vars, Eigen::VectorXd coeffs, Eigen::VectorXd targets, int& first_step, int& last_step);
+  JointPosEqConstraint(VarArray vars,
+                       const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                       const Eigen::Ref<const Eigen::VectorXd>& targets,
+                       int first_step,
+                       int last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   sco::ConvexConstraints::Ptr convex(const DblVec& x, sco::Model* model) override;
   /** @brief Numerically evaluate cost given the vector of values */
@@ -108,12 +116,12 @@ class TRAJOPT_API JointPosIneqConstraint : public sco::IneqConstraint
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
   JointPosIneqConstraint(VarArray vars,
-                         Eigen::VectorXd coeffs,
-                         Eigen::VectorXd targets,
-                         Eigen::VectorXd upper_limits,
-                         Eigen::VectorXd lower_limits,
-                         int& first_step,
-                         int& last_step);
+                         const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                         const Eigen::Ref<const Eigen::VectorXd>& targets,
+                         const Eigen::Ref<const Eigen::VectorXd>& upper_limits,
+                         const Eigen::Ref<const Eigen::VectorXd>& lower_limits,
+                         int first_step,
+                         int last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   sco::ConvexConstraints::Ptr convex(const DblVec& x, sco::Model* model) override;
   /** @brief Numerically evaluate cost given the vector of values */
@@ -143,7 +151,11 @@ class TRAJOPT_API JointVelEqCost : public sco::Cost
 {
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
-  JointVelEqCost(VarArray vars, Eigen::VectorXd coeffs, Eigen::VectorXd targets, int& first_step, int& last_step);
+  JointVelEqCost(VarArray vars,
+                 const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                 const Eigen::Ref<const Eigen::VectorXd>& targets,
+                 int first_step,
+                 int last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   sco::ConvexObjective::Ptr convex(const DblVec& x, sco::Model* model) override;
   /** @brief Numerically evaluate cost given the vector of values using Eigen*/
@@ -170,12 +182,12 @@ class TRAJOPT_API JointVelIneqCost : public sco::Cost
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
   JointVelIneqCost(VarArray vars,
-                   Eigen::VectorXd coeffs,
-                   Eigen::VectorXd targets,
-                   Eigen::VectorXd upper_limits,
-                   Eigen::VectorXd lower_limits,
-                   int& first_step,
-                   int& last_step);
+                   const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                   const Eigen::Ref<const Eigen::VectorXd>& targets,
+                   const Eigen::Ref<const Eigen::VectorXd>& upper_limits,
+                   const Eigen::Ref<const Eigen::VectorXd>& lower_limits,
+                   int first_step,
+                   int last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   sco::ConvexObjective::Ptr convex(const DblVec& x, sco::Model* model) override;
   /** @brief Numerically evaluate cost given the vector of values */
@@ -205,7 +217,11 @@ class TRAJOPT_API JointVelEqConstraint : public sco::EqConstraint
 {
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
-  JointVelEqConstraint(VarArray vars, Eigen::VectorXd coeffs, Eigen::VectorXd targets, int& first_step, int& last_step);
+  JointVelEqConstraint(VarArray vars,
+                       const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                       const Eigen::Ref<const Eigen::VectorXd>& targets,
+                       int first_step,
+                       int last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   sco::ConvexConstraints::Ptr convex(const DblVec& x, sco::Model* model) override;
   /** @brief Numerically evaluate cost given the vector of values */
@@ -233,12 +249,12 @@ class TRAJOPT_API JointVelIneqConstraint : public sco::IneqConstraint
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
   JointVelIneqConstraint(VarArray vars,
-                         Eigen::VectorXd coeffs,
-                         Eigen::VectorXd targets,
-                         Eigen::VectorXd upper_limits,
-                         Eigen::VectorXd lower_limits,
-                         int& first_step,
-                         int& last_step);
+                         const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                         const Eigen::Ref<const Eigen::VectorXd>& targets,
+                         const Eigen::Ref<const Eigen::VectorXd>& upper_limits,
+                         const Eigen::Ref<const Eigen::VectorXd>& lower_limits,
+                         int first_step,
+                         int last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   sco::ConvexConstraints::Ptr convex(const DblVec& x, sco::Model* model) override;
   /** @brief Numerically evaluate cost given the vector of values */
@@ -268,7 +284,11 @@ class TRAJOPT_API JointAccEqCost : public sco::Cost
 {
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
-  JointAccEqCost(VarArray vars, Eigen::VectorXd coeffs, Eigen::VectorXd targets, int& first_step, int& last_step);
+  JointAccEqCost(VarArray vars,
+                 const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                 const Eigen::Ref<const Eigen::VectorXd>& targets,
+                 int first_step,
+                 int last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   sco::ConvexObjective::Ptr convex(const DblVec& x, sco::Model* model) override;
   /** @brief Numerically evaluate cost given the vector of values */
@@ -295,12 +315,12 @@ class TRAJOPT_API JointAccIneqCost : public sco::Cost
 public:
   /** @brief Forms error in a vector of AffExpr - independent of penalty type */
   JointAccIneqCost(VarArray vars,
-                   Eigen::VectorXd coeffs,
-                   Eigen::VectorXd targets,
-                   Eigen::VectorXd upper_limits,
-                   Eigen::VectorXd lower_limits,
-                   int& first_step,
-                   int& last_step);
+                   const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                   const Eigen::Ref<const Eigen::VectorXd>& targets,
+                   const Eigen::Ref<const Eigen::VectorXd>& upper_limits,
+                   const Eigen::Ref<const Eigen::VectorXd>& lower_limits,
+                   int first_step,
+                   int last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   sco::ConvexObjective::Ptr convex(const DblVec& x, sco::Model* model) override;
   /** @brief Numerically evaluate cost given the vector of values */
@@ -330,7 +350,11 @@ class TRAJOPT_API JointAccEqConstraint : public sco::EqConstraint
 {
 public:
   /** @brief Forms error in a vector of AffExpr - independent of penalty type */
-  JointAccEqConstraint(VarArray vars, Eigen::VectorXd coeffs, Eigen::VectorXd targets, int& first_step, int& last_step);
+  JointAccEqConstraint(VarArray vars,
+                       const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                       const Eigen::Ref<const Eigen::VectorXd>& targets,
+                       int first_step,
+                       int last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   sco::ConvexConstraints::Ptr convex(const DblVec& x, sco::Model* model) override;
   /** @brief Numerically evaluate cost given the vector of values */
@@ -358,12 +382,12 @@ class TRAJOPT_API JointAccIneqConstraint : public sco::IneqConstraint
 public:
   /** @brief Forms error in a vector of AffExpr - independent of penalty type */
   JointAccIneqConstraint(VarArray vars,
-                         Eigen::VectorXd coeffs,
-                         Eigen::VectorXd targets,
-                         Eigen::VectorXd upper_limits,
-                         Eigen::VectorXd lower_limits,
-                         int& first_step,
-                         int& last_step);
+                         const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                         const Eigen::Ref<const Eigen::VectorXd>& targets,
+                         const Eigen::Ref<const Eigen::VectorXd>& upper_limits,
+                         const Eigen::Ref<const Eigen::VectorXd>& lower_limits,
+                         int first_step,
+                         int last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   sco::ConvexConstraints::Ptr convex(const DblVec& x, sco::Model* model) override;
   /** @brief Numerically evaluate cost given the vector of values */
@@ -393,7 +417,11 @@ class TRAJOPT_API JointJerkEqCost : public sco::Cost
 {
 public:
   /** @brief Forms error in QuadExpr - independent of penalty type */
-  JointJerkEqCost(VarArray vars, Eigen::VectorXd coeffs, Eigen::VectorXd targets, int& first_step, int& last_step);
+  JointJerkEqCost(VarArray vars,
+                  const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                  const Eigen::Ref<const Eigen::VectorXd>& targets,
+                  int first_step,
+                  int last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   sco::ConvexObjective::Ptr convex(const DblVec& x, sco::Model* model) override;
   /** @brief Numerically evaluate cost given the vector of values */
@@ -420,12 +448,12 @@ class TRAJOPT_API JointJerkIneqCost : public sco::Cost
 public:
   /** @brief Forms error in a vector of AffExpr - independent of penalty type */
   JointJerkIneqCost(VarArray vars,
-                    Eigen::VectorXd coeffs,
-                    Eigen::VectorXd targets,
-                    Eigen::VectorXd upper_limits,
-                    Eigen::VectorXd lower_limits,
-                    int& first_step,
-                    int& last_step);
+                    const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                    const Eigen::Ref<const Eigen::VectorXd>& targets,
+                    const Eigen::Ref<const Eigen::VectorXd>& upper_limits,
+                    const Eigen::Ref<const Eigen::VectorXd>& lower_limits,
+                    int first_step,
+                    int last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   sco::ConvexObjective::Ptr convex(const DblVec& x, sco::Model* model) override;
   /** @brief Numerically evaluate cost given the vector of values */
@@ -456,10 +484,10 @@ class TRAJOPT_API JointJerkEqConstraint : public sco::EqConstraint
 public:
   /** @brief Forms error in a vector of AffExpr - independent of penalty type */
   JointJerkEqConstraint(VarArray vars,
-                        Eigen::VectorXd coeffs,
-                        Eigen::VectorXd targets,
-                        int& first_step,
-                        int& last_step);
+                        const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                        const Eigen::Ref<const Eigen::VectorXd>& targets,
+                        int first_step,
+                        int last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   sco::ConvexConstraints::Ptr convex(const DblVec& x, sco::Model* model) override;
   /** @brief Numerically evaluate cost given the vector of values */
@@ -487,12 +515,12 @@ class TRAJOPT_API JointJerkIneqConstraint : public sco::IneqConstraint
 public:
   /** @brief Forms error in a vector of AffExpr - independent of penalty type */
   JointJerkIneqConstraint(VarArray vars,
-                          Eigen::VectorXd coeffs,
-                          Eigen::VectorXd targets,
-                          Eigen::VectorXd upper_limits,
-                          Eigen::VectorXd lower_limits,
-                          int& first_step,
-                          int& last_step);
+                          const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                          const Eigen::Ref<const Eigen::VectorXd>& targets,
+                          const Eigen::Ref<const Eigen::VectorXd>& upper_limits,
+                          const Eigen::Ref<const Eigen::VectorXd>& lower_limits,
+                          int first_step,
+                          int last_step);
   /** @brief Convexifies cost expression - In this case, it is already quadratic so there's nothing to do */
   sco::ConvexConstraints::Ptr convex(const DblVec& x, sco::Model* model) override;
   /** @brief Numerically evaluate cost given the vector of values */

--- a/trajopt/src/trajectory_costs.cpp
+++ b/trajopt/src/trajectory_costs.cpp
@@ -23,14 +23,14 @@ namespace trajopt
 
 //////////////////// Position /////////////////////
 JointPosEqCost::JointPosEqCost(VarArray vars,
-                               Eigen::VectorXd coeffs,
-                               Eigen::VectorXd targets,
-                               int& first_step,
-                               int& last_step)
+                               const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                               const Eigen::Ref<const Eigen::VectorXd>& targets,
+                               int first_step,
+                               int last_step)
   : Cost("JointPosEq")
   , vars_(std::move(vars))
-  , coeffs_(std::move(coeffs))
-  , targets_(std::move(targets))
+  , coeffs_(coeffs)
+  , targets_(targets)
   , first_step_(first_step)
   , last_step_(last_step)
 {
@@ -65,18 +65,18 @@ sco::ConvexObjective::Ptr JointPosEqCost::convex(const DblVec& /*x*/, sco::Model
 }
 
 JointPosIneqCost::JointPosIneqCost(VarArray vars,
-                                   Eigen::VectorXd coeffs,
-                                   Eigen::VectorXd targets,
-                                   Eigen::VectorXd upper_limits,
-                                   Eigen::VectorXd lower_limits,
-                                   int& first_step,
-                                   int& last_step)
+                                   const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                                   const Eigen::Ref<const Eigen::VectorXd>& targets,
+                                   const Eigen::Ref<const Eigen::VectorXd>& upper_limits,
+                                   const Eigen::Ref<const Eigen::VectorXd>& lower_limits,
+                                   int first_step,
+                                   int last_step)
   : Cost("JointPosIneq")
   , vars_(std::move(vars))
-  , coeffs_(std::move(coeffs))
-  , upper_tols_(std::move(upper_limits))
-  , lower_tols_(std::move(lower_limits))
-  , targets_(std::move(targets))
+  , coeffs_(coeffs)
+  , upper_tols_(upper_limits)
+  , lower_tols_(lower_limits)
+  , targets_(targets)
   , first_step_(first_step)
   , last_step_(last_step)
 {
@@ -133,14 +133,14 @@ sco::ConvexObjective::Ptr JointPosIneqCost::convex(const DblVec& /*x*/, sco::Mod
 }
 
 JointPosEqConstraint::JointPosEqConstraint(VarArray vars,
-                                           Eigen::VectorXd coeffs,
-                                           Eigen::VectorXd targets,
-                                           int& first_step,
-                                           int& last_step)
+                                           const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                                           const Eigen::Ref<const Eigen::VectorXd>& targets,
+                                           int first_step,
+                                           int last_step)
   : EqConstraint("JointPosEq")
   , vars_(std::move(vars))
-  , coeffs_(std::move(coeffs))
-  , targets_(std::move(targets))
+  , coeffs_(coeffs)
+  , targets_(targets)
   , first_step_(first_step)
   , last_step_(last_step)
 {
@@ -179,18 +179,18 @@ sco::ConvexConstraints::Ptr JointPosEqConstraint::convex(const DblVec& /*x*/, sc
 }
 
 JointPosIneqConstraint::JointPosIneqConstraint(VarArray vars,
-                                               Eigen::VectorXd coeffs,
-                                               Eigen::VectorXd targets,
-                                               Eigen::VectorXd upper_limits,
-                                               Eigen::VectorXd lower_limits,
-                                               int& first_step,
-                                               int& last_step)
+                                               const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                                               const Eigen::Ref<const Eigen::VectorXd>& targets,
+                                               const Eigen::Ref<const Eigen::VectorXd>& upper_limits,
+                                               const Eigen::Ref<const Eigen::VectorXd>& lower_limits,
+                                               int first_step,
+                                               int last_step)
   : IneqConstraint("JointPosIneq")
   , vars_(std::move(vars))
-  , coeffs_(std::move(coeffs))
-  , upper_tols_(std::move(upper_limits))
-  , lower_tols_(std::move(lower_limits))
-  , targets_(std::move(targets))
+  , coeffs_(coeffs)
+  , upper_tols_(upper_limits)
+  , lower_tols_(lower_limits)
+  , targets_(targets)
   , first_step_(first_step)
   , last_step_(last_step)
 {
@@ -250,14 +250,14 @@ sco::ConvexConstraints::Ptr JointPosIneqConstraint::convex(const DblVec& /*x*/, 
 
 //////////////////// Velocity /////////////////////
 JointVelEqCost::JointVelEqCost(VarArray vars,
-                               Eigen::VectorXd coeffs,
-                               Eigen::VectorXd targets,
-                               int& first_step,
-                               int& last_step)
+                               const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                               const Eigen::Ref<const Eigen::VectorXd>& targets,
+                               int first_step,
+                               int last_step)
   : Cost("JointVelEq")
   , vars_(std::move(vars))
-  , coeffs_(std::move(coeffs))
-  , targets_(std::move(targets))
+  , coeffs_(coeffs)
+  , targets_(targets)
   , first_step_(first_step)
   , last_step_(last_step)
 {
@@ -293,18 +293,18 @@ sco::ConvexObjective::Ptr JointVelEqCost::convex(const DblVec& /*x*/, sco::Model
 }
 
 JointVelIneqCost::JointVelIneqCost(VarArray vars,
-                                   Eigen::VectorXd coeffs,
-                                   Eigen::VectorXd targets,
-                                   Eigen::VectorXd upper_limits,
-                                   Eigen::VectorXd lower_limits,
-                                   int& first_step,
-                                   int& last_step)
+                                   const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                                   const Eigen::Ref<const Eigen::VectorXd>& targets,
+                                   const Eigen::Ref<const Eigen::VectorXd>& upper_limits,
+                                   const Eigen::Ref<const Eigen::VectorXd>& lower_limits,
+                                   int first_step,
+                                   int last_step)
   : Cost("JointVelIneq")
   , vars_(std::move(vars))
-  , coeffs_(std::move(coeffs))
-  , upper_tols_(std::move(upper_limits))
-  , lower_tols_(std::move(lower_limits))
-  , targets_(std::move(targets))
+  , coeffs_(coeffs)
+  , upper_tols_(upper_limits)
+  , lower_tols_(lower_limits)
+  , targets_(targets)
   , first_step_(first_step)
   , last_step_(last_step)
 {
@@ -363,14 +363,14 @@ sco::ConvexObjective::Ptr JointVelIneqCost::convex(const DblVec& /*x*/, sco::Mod
 }
 
 JointVelEqConstraint::JointVelEqConstraint(VarArray vars,
-                                           Eigen::VectorXd coeffs,
-                                           Eigen::VectorXd targets,
-                                           int& first_step,
-                                           int& last_step)
+                                           const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                                           const Eigen::Ref<const Eigen::VectorXd>& targets,
+                                           int first_step,
+                                           int last_step)
   : EqConstraint("JointVelEq")
   , vars_(std::move(vars))
-  , coeffs_(std::move(coeffs))
-  , targets_(std::move(targets))
+  , coeffs_(coeffs)
+  , targets_(targets)
   , first_step_(first_step)
   , last_step_(last_step)
 {
@@ -410,18 +410,18 @@ sco::ConvexConstraints::Ptr JointVelEqConstraint::convex(const DblVec& /*x*/, sc
 }
 
 JointVelIneqConstraint::JointVelIneqConstraint(VarArray vars,
-                                               Eigen::VectorXd coeffs,
-                                               Eigen::VectorXd targets,
-                                               Eigen::VectorXd upper_limits,
-                                               Eigen::VectorXd lower_limits,
-                                               int& first_step,
-                                               int& last_step)
+                                               const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                                               const Eigen::Ref<const Eigen::VectorXd>& targets,
+                                               const Eigen::Ref<const Eigen::VectorXd>& upper_limits,
+                                               const Eigen::Ref<const Eigen::VectorXd>& lower_limits,
+                                               int first_step,
+                                               int last_step)
   : IneqConstraint("JointVelIneq")
   , vars_(std::move(vars))
-  , coeffs_(std::move(coeffs))
-  , upper_tols_(std::move(upper_limits))
-  , lower_tols_(std::move(lower_limits))
-  , targets_(std::move(targets))
+  , coeffs_(coeffs)
+  , upper_tols_(upper_limits)
+  , lower_tols_(lower_limits)
+  , targets_(targets)
   , first_step_(first_step)
   , last_step_(last_step)
 {
@@ -483,14 +483,14 @@ sco::ConvexConstraints::Ptr JointVelIneqConstraint::convex(const DblVec& /*x*/, 
 
 //////////////////// Acceleration /////////////////////
 JointAccEqCost::JointAccEqCost(VarArray vars,
-                               Eigen::VectorXd coeffs,
-                               Eigen::VectorXd targets,
-                               int& first_step,
-                               int& last_step)
+                               const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                               const Eigen::Ref<const Eigen::VectorXd>& targets,
+                               int first_step,
+                               int last_step)
   : Cost("JointAccEq")
   , vars_(std::move(vars))
-  , coeffs_(std::move(coeffs))
-  , targets_(std::move(targets))
+  , coeffs_(coeffs)
+  , targets_(targets)
   , first_step_(first_step)
   , last_step_(last_step)
 {
@@ -529,18 +529,18 @@ sco::ConvexObjective::Ptr JointAccEqCost::convex(const DblVec& /*x*/, sco::Model
 }
 
 JointAccIneqCost::JointAccIneqCost(VarArray vars,
-                                   Eigen::VectorXd coeffs,
-                                   Eigen::VectorXd targets,
-                                   Eigen::VectorXd upper_limits,
-                                   Eigen::VectorXd lower_limits,
-                                   int& first_step,
-                                   int& last_step)
+                                   const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                                   const Eigen::Ref<const Eigen::VectorXd>& targets,
+                                   const Eigen::Ref<const Eigen::VectorXd>& upper_limits,
+                                   const Eigen::Ref<const Eigen::VectorXd>& lower_limits,
+                                   int first_step,
+                                   int last_step)
   : Cost("JointAccIneq")
   , vars_(std::move(vars))
-  , coeffs_(std::move(coeffs))
-  , upper_tols_(std::move(upper_limits))
-  , lower_tols_(std::move(lower_limits))
-  , targets_(std::move(targets))
+  , coeffs_(coeffs)
+  , upper_tols_(upper_limits)
+  , lower_tols_(lower_limits)
+  , targets_(targets)
   , first_step_(first_step)
   , last_step_(last_step)
 {
@@ -600,14 +600,14 @@ sco::ConvexObjective::Ptr JointAccIneqCost::convex(const DblVec& /*x*/, sco::Mod
 }
 
 JointAccEqConstraint::JointAccEqConstraint(VarArray vars,
-                                           Eigen::VectorXd coeffs,
-                                           Eigen::VectorXd targets,
-                                           int& first_step,
-                                           int& last_step)
+                                           const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                                           const Eigen::Ref<const Eigen::VectorXd>& targets,
+                                           int first_step,
+                                           int last_step)
   : EqConstraint("JointAccEq")
   , vars_(std::move(vars))
-  , coeffs_(std::move(coeffs))
-  , targets_(std::move(targets))
+  , coeffs_(coeffs)
+  , targets_(targets)
   , first_step_(first_step)
   , last_step_(last_step)
 {
@@ -650,18 +650,18 @@ sco::ConvexConstraints::Ptr JointAccEqConstraint::convex(const DblVec& /*x*/, sc
 }
 
 JointAccIneqConstraint::JointAccIneqConstraint(VarArray vars,
-                                               Eigen::VectorXd coeffs,
-                                               Eigen::VectorXd targets,
-                                               Eigen::VectorXd upper_limits,
-                                               Eigen::VectorXd lower_limits,
-                                               int& first_step,
-                                               int& last_step)
+                                               const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                                               const Eigen::Ref<const Eigen::VectorXd>& targets,
+                                               const Eigen::Ref<const Eigen::VectorXd>& upper_limits,
+                                               const Eigen::Ref<const Eigen::VectorXd>& lower_limits,
+                                               int first_step,
+                                               int last_step)
   : IneqConstraint("JointAccIneq")
   , vars_(std::move(vars))
-  , coeffs_(std::move(coeffs))
-  , upper_tols_(std::move(upper_limits))
-  , lower_tols_(std::move(lower_limits))
-  , targets_(std::move(targets))
+  , coeffs_(coeffs)
+  , upper_tols_(upper_limits)
+  , lower_tols_(lower_limits)
+  , targets_(targets)
   , first_step_(first_step)
   , last_step_(last_step)
 {
@@ -725,14 +725,14 @@ sco::ConvexConstraints::Ptr JointAccIneqConstraint::convex(const DblVec& /*x*/, 
 
 //////////////////// Jerk /////////////////////
 JointJerkEqCost::JointJerkEqCost(VarArray vars,
-                                 Eigen::VectorXd coeffs,
-                                 Eigen::VectorXd targets,
-                                 int& first_step,
-                                 int& last_step)
+                                 const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                                 const Eigen::Ref<const Eigen::VectorXd>& targets,
+                                 int first_step,
+                                 int last_step)
   : Cost("JointJerkEq")
   , vars_(std::move(vars))
-  , coeffs_(std::move(coeffs))
-  , targets_(std::move(targets))
+  , coeffs_(coeffs)
+  , targets_(targets)
   , first_step_(first_step)
   , last_step_(last_step)
 {
@@ -773,18 +773,18 @@ sco::ConvexObjective::Ptr JointJerkEqCost::convex(const DblVec& /*x*/, sco::Mode
 }
 
 JointJerkIneqCost::JointJerkIneqCost(VarArray vars,
-                                     Eigen::VectorXd coeffs,
-                                     Eigen::VectorXd targets,
-                                     Eigen::VectorXd upper_limits,
-                                     Eigen::VectorXd lower_limits,
-                                     int& first_step,
-                                     int& last_step)
+                                     const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                                     const Eigen::Ref<const Eigen::VectorXd>& targets,
+                                     const Eigen::Ref<const Eigen::VectorXd>& upper_limits,
+                                     const Eigen::Ref<const Eigen::VectorXd>& lower_limits,
+                                     int first_step,
+                                     int last_step)
   : Cost("JointJerkIneq")
   , vars_(std::move(vars))
-  , coeffs_(std::move(coeffs))
-  , upper_tols_(std::move(upper_limits))
-  , lower_tols_(std::move(lower_limits))
-  , targets_(std::move(targets))
+  , coeffs_(coeffs)
+  , upper_tols_(upper_limits)
+  , lower_tols_(lower_limits)
+  , targets_(targets)
   , first_step_(first_step)
   , last_step_(last_step)
 {
@@ -846,14 +846,14 @@ sco::ConvexObjective::Ptr JointJerkIneqCost::convex(const DblVec& /*x*/, sco::Mo
 }
 
 JointJerkEqConstraint::JointJerkEqConstraint(VarArray vars,
-                                             Eigen::VectorXd coeffs,
-                                             Eigen::VectorXd targets,
-                                             int& first_step,
-                                             int& last_step)
+                                             const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                                             const Eigen::Ref<const Eigen::VectorXd>& targets,
+                                             int first_step,
+                                             int last_step)
   : EqConstraint("JointJerkEq")
   , vars_(std::move(vars))
-  , coeffs_(std::move(coeffs))
-  , targets_(std::move(targets))
+  , coeffs_(coeffs)
+  , targets_(targets)
   , first_step_(first_step)
   , last_step_(last_step)
 {
@@ -898,18 +898,18 @@ sco::ConvexConstraints::Ptr JointJerkEqConstraint::convex(const DblVec& /*x*/, s
 }
 
 JointJerkIneqConstraint::JointJerkIneqConstraint(VarArray vars,
-                                                 Eigen::VectorXd coeffs,
-                                                 Eigen::VectorXd targets,
-                                                 Eigen::VectorXd upper_limits,
-                                                 Eigen::VectorXd lower_limits,
-                                                 int& first_step,
-                                                 int& last_step)
+                                                 const Eigen::Ref<const Eigen::VectorXd>& coeffs,
+                                                 const Eigen::Ref<const Eigen::VectorXd>& targets,
+                                                 const Eigen::Ref<const Eigen::VectorXd>& upper_limits,
+                                                 const Eigen::Ref<const Eigen::VectorXd>& lower_limits,
+                                                 int first_step,
+                                                 int last_step)
   : IneqConstraint("JointJerkIneq")
   , vars_(std::move(vars))
-  , coeffs_(std::move(coeffs))
-  , upper_tols_(std::move(upper_limits))
-  , lower_tols_(std::move(lower_limits))
-  , targets_(std::move(targets))
+  , coeffs_(coeffs)
+  , upper_tols_(upper_limits)
+  , lower_tols_(lower_limits)
+  , targets_(targets)
   , first_step_(first_step)
   , last_step_(last_step)
 {

--- a/trajopt/test/data/config/arm_around_table.json
+++ b/trajopt/test/data/config/arm_around_table.json
@@ -17,7 +17,7 @@
     "params" : {
       "coeffs" : [20],
       "dist_pen" : [0.025],
-      "continuous" : true
+      "evaluator_type" : 2
     }
   }
   ],

--- a/trajopt/test/data/config/arm_around_table_continuous.json
+++ b/trajopt/test/data/config/arm_around_table_continuous.json
@@ -17,7 +17,7 @@
     "type" : "collision",
     "name" : "collision",
     "params" : {
-      "continuous" : true,
+      "evaluator_type" : 2,
       "coeffs" : [20],
       "dist_pen" : [0.025]
     }

--- a/trajopt/test/data/config/arm_around_table_time.json
+++ b/trajopt/test/data/config/arm_around_table_time.json
@@ -18,7 +18,7 @@
     "params" : {
       "coeffs" : [20],
       "dist_pen" : [0.025],
-      "continuous" : true
+      "evaluator_type" : 2
     }
   }
   ],

--- a/trajopt/test/data/config/box_cast_test.json
+++ b/trajopt/test/data/config/box_cast_test.json
@@ -17,7 +17,7 @@
     "type" : "collision",
     "name" : "cc",
     "params" : {
-      "continuous":true,
+      "evaluator_type": 2,
       "coeffs" : [10],
       "dist_pen" : [0.2]
     }


### PR DESCRIPTION
This updates casted collision evaluator to handle fixed start or end states. Before we just would exclude but that is not ideal because you would periodically get post check failures  between the start and first waypoint and next to last waypoint and the end waypoint. 

Also this PR includes updating the constructors to pass eigen types by reference. The documentation states not to pass eigen types by value and I know in the past we have had eigen issues.