### PR TITLE
Change Default Solver

### DIFF
--- a/trajopt_ext/osqp/CMakeLists.txt
+++ b/trajopt_ext/osqp/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.5.0)
+project(osqp)
+
+find_package(osqp QUIET)
+
+if (NOT ${osqp_FOUND})
+  message(WARNING "No valid OSQP version found. Cloning OSQP 0.6.0 into build directory")
+
+  include(ExternalProject)
+
+  ExternalProject_Add(osqp
+    GIT_REPOSITORY    https://github.com/oxfordcontrol/osqp
+    GIT_TAG           v0.6.0
+    GIT_SHALLOW       ON
+    SOURCE_DIR        ${CMAKE_BINARY_DIR}/../trajopt_ext/osqp-src
+    BINARY_DIR        ${CMAKE_BINARY_DIR}/../trajopt_ext/osqp-build
+    CMAKE_CACHE_ARGS
+            -DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_INSTALL_PREFIX}
+            -DCMAKE_BUILD_TYPE:STRING=Release
+  )
+endif()
+
+install(FILES package.xml DESTINATION share/osqp)

--- a/trajopt_ext/osqp/package.xml
+++ b/trajopt_ext/osqp/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>osqp</name>
+  <version>0.1.0</version>
+  <description>OSQP Package</description>
+  <maintainer email="levi.armstrong@swri.org">Levi Armstrong</maintainer>
+  <license>Unknown</license>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+
+</package>

--- a/trajopt_sco/src/solver_interface.cpp
+++ b/trajopt_sco/src/solver_interface.cpp
@@ -204,11 +204,11 @@ std::vector<ModelType> availableSolvers()
 #ifdef HAVE_GUROBI
   has_solver[ModelType::GUROBI] = true;
 #endif
-#ifdef HAVE_BPMPD
-  has_solver[ModelType::BPMPD] = true;
-#endif
 #ifdef HAVE_OSQP
   has_solver[ModelType::OSQP] = true;
+#endif
+#ifdef HAVE_BPMPD
+  has_solver[ModelType::BPMPD] = true;
 #endif
 #ifdef HAVE_QPOASES
   has_solver[ModelType::QPOASES] = true;
@@ -231,11 +231,11 @@ Model::Ptr createModel(ModelType model_type)
 #ifdef HAVE_GUROBI
   extern Model::Ptr createGurobiModel();
 #endif
-#ifdef HAVE_BPMPD
-  extern Model::Ptr createBPMPDModel();
-#endif
 #ifdef HAVE_OSQP
   extern Model::Ptr createOSQPModel();
+#endif
+#ifdef HAVE_BPMPD
+  extern Model::Ptr createBPMPDModel();
 #endif
 #ifdef HAVE_QPOASES
   extern Model::Ptr createqpOASESModel();
@@ -268,13 +268,13 @@ Model::Ptr createModel(ModelType model_type)
   if (solver == ModelType::GUROBI)
     PRINT_AND_THROW("you didn't build with GUROBI support");
 #endif
-#ifndef HAVE_BPMPD
-  if (solver == ModelType::BPMPD)
-    PRINT_AND_THROW("you don't have BPMPD support on this platform");
-#endif
 #ifndef HAVE_OSQP
   if (solver == ModelType::OSQP)
     PRINT_AND_THROW("you don't have OSQP support on this platform");
+#endif
+#ifndef HAVE_BPMPD
+  if (solver == ModelType::BPMPD)
+    PRINT_AND_THROW("you don't have BPMPD support on this platform");
 #endif
 #ifndef HAVE_QPOASES
   if (solver == ModelType::QPOASES)
@@ -285,13 +285,13 @@ Model::Ptr createModel(ModelType model_type)
   if (solver == ModelType::GUROBI)
     return createGurobiModel();
 #endif
-#ifdef HAVE_BPMPD
-  if (solver == ModelType::BPMPD)
-    return createBPMPDModel();
-#endif
 #ifdef HAVE_OSQP
   if (solver == ModelType::OSQP)
     return createOSQPModel();
+#endif
+#ifdef HAVE_BPMPD
+  if (solver == ModelType::BPMPD)
+    return createBPMPDModel();
 #endif
 #ifdef HAVE_QPOASES
   if (solver == ModelType::QPOASES)


### PR DESCRIPTION
Gurobi is still the preferred solver, but the default solver assuming no other setup has been done on the computer will now be OSQP. This has been added to Trajopt_ext. If OSQP is not found at compile time, it will clone it into the build directory and compile it. 

The motivation behind this is that BPMPD has a noncommercial license. By changing the default solver to OSQP we limit the chance that someone uses BPMPD in a commercial application inadvertently. It will now require an intentional change.

The new order for AUTO_SOLVER is 
* Gurobi
* OSQP
* BPMPD
* qpOASES