### PR TITLE
Add unique_ptrs A and P to osqp interface

### DIFF
--- a/trajopt_sco/include/trajopt_sco/osqp_interface.hpp
+++ b/trajopt_sco/include/trajopt_sco/osqp_interface.hpp
@@ -27,8 +27,9 @@ class OSQPModel : public Model
                                /** OSQPData. Some fields here (`osp_data_.A` and `osp_data_.P`) are
                                 *  automatically allocated by OSQP, but deallocated by us. */
   OSQPData osqp_data_;
+
   /** OSQP Workspace. Memory here is managed by OSQP */
-  OSQPWorkspace* osqp_workspace_;
+  std::unique_ptr<OSQPWorkspace, std::function<void(OSQPWorkspace*)>> osqp_workspace_;
 
   /** Updates OSQP quadratic cost matrix from QuadExpr expression.
    *  Transforms QuadExpr objective_ into the OSQP CSC matrix P_ */
@@ -49,8 +50,8 @@ class OSQPModel : public Model
   ConstraintTypeVector cnt_types_; /**< constraints types */
   DblVec solution_;                /**< optimizizer's solution for current model */
 
-  std::unique_ptr<csc> P_;               /**< Takes ownershipt of OSQPData.P to avoid having to deallocate manually */
-  std::unique_ptr<csc> A_;               /**< Takes ownershipt of OSQPData.A to avoid having to deallocate manually */
+  std::unique_ptr<csc> P_;               /**< Takes ownership of OSQPData.P to avoid having to deallocate manually */
+  std::unique_ptr<csc> A_;               /**< Takes ownership of OSQPData.A to avoid having to deallocate manually */
   std::vector<c_int> P_row_indices_;     /**< row indices for P, CSC format */
   std::vector<c_int> P_column_pointers_; /**< column pointers for P, CSC format */
   DblVec P_csc_data_;                    /**< P values in CSC format */
@@ -65,14 +66,9 @@ class OSQPModel : public Model
 
 public:
   OSQPModel();
-  ~OSQPModel() override;
-  OSQPModel(const OSQPModel& model) : Model(model), P_(new csc{}), A_(new csc{}) {}
-  OSQPModel& operator=(const OSQPModel&)
-  {
-    A_ = std::make_unique<csc>();
-    P_ = std::make_unique<csc>();
-    return *this;
-  }
+  ~OSQPModel() override = default;
+  OSQPModel(const OSQPModel& model) = delete;
+  OSQPModel& operator=(const OSQPModel& model) = delete;
   OSQPModel(OSQPModel&&) = default;
   OSQPModel& operator=(OSQPModel&&) = default;
 

--- a/trajopt_sco/include/trajopt_sco/osqp_interface.hpp
+++ b/trajopt_sco/include/trajopt_sco/osqp_interface.hpp
@@ -49,6 +49,8 @@ class OSQPModel : public Model
   ConstraintTypeVector cnt_types_; /**< constraints types */
   DblVec solution_;                /**< optimizizer's solution for current model */
 
+  std::unique_ptr<csc> P_;               /**< Takes ownershipt of OSQPData.P to avoid having to deallocate manually */
+  std::unique_ptr<csc> A_;               /**< Takes ownershipt of OSQPData.A to avoid having to deallocate manually */
   std::vector<c_int> P_row_indices_;     /**< row indices for P, CSC format */
   std::vector<c_int> P_column_pointers_; /**< column pointers for P, CSC format */
   DblVec P_csc_data_;                    /**< P values in CSC format */
@@ -64,8 +66,13 @@ class OSQPModel : public Model
 public:
   OSQPModel();
   ~OSQPModel() override;
-  OSQPModel(const OSQPModel&) = default;
-  OSQPModel& operator=(const OSQPModel&) = default;
+  OSQPModel(const OSQPModel& model) : Model(model), P_(new csc{}), A_(new csc{}) {}
+  OSQPModel& operator=(const OSQPModel&)
+  {
+    A_ = std::make_unique<csc>();
+    P_ = std::make_unique<csc>();
+    return *this;
+  }
   OSQPModel(OSQPModel&&) = default;
   OSQPModel& operator=(OSQPModel&&) = default;
 

--- a/trajopt_sco/src/osqp_interface.cpp
+++ b/trajopt_sco/src/osqp_interface.cpp
@@ -23,6 +23,9 @@ Model::Ptr createOSQPModel()
 }
 
 OSQPModel::OSQPModel()
+  : osqp_workspace_(new OSQPWorkspace, [](OSQPWorkspace* ptr) { osqp_cleanup(ptr); })
+  , P_(osqp_data_.P)
+  , A_(osqp_data_.A)
 {
   // Define Solver settings as default
   // see https://osqp.org/docs/interfaces/solver_settings.html#solver-settings
@@ -33,18 +36,6 @@ OSQPModel::OSQPModel()
   osqp_settings_.max_iter = 8192;
   osqp_settings_.polish = 1;
   osqp_settings_.verbose = false;
-
-  // Initialize data
-  A_.reset(osqp_data_.A);
-  P_.reset(osqp_data_.P);
-  osqp_workspace_ = nullptr;
-}
-
-OSQPModel::~OSQPModel()
-{
-  // Cleanup
-  if (osqp_workspace_ != nullptr)
-    osqp_cleanup(osqp_workspace_);
 }
 
 Var OSQPModel::addVar(const std::string& name)
@@ -168,10 +159,10 @@ void OSQPModel::createOrUpdateSolver()
 
   // TODO atm we are not updating the workspace, but recreating it each time.
   // In the future, we will checking sparsity did not change and update instead
-  if (osqp_workspace_ != nullptr)
-    osqp_cleanup(osqp_workspace_);
+
   // Setup workspace - this should be called only once
-  auto ret = osqp_setup(&osqp_workspace_, &osqp_data_, &osqp_settings_);
+  OSQPWorkspace* tmp = osqp_workspace_.get();
+  auto ret = osqp_setup(&tmp, &osqp_data_, &osqp_settings_);
   if (ret)
   {
     throw std::runtime_error("Could not initialize OSQP: error " + std::to_string(ret));
@@ -248,7 +239,7 @@ CvxOptStatus OSQPModel::optimize()
   createOrUpdateSolver();
 
   // Solve Problem
-  const c_int retcode = osqp_solve(osqp_workspace_);
+  const c_int retcode = osqp_solve(osqp_workspace_.get());
 
   if (retcode == 0)
   {


### PR DESCRIPTION
Apparently OSQP allocates A and P leaving us to deallocated them. This PR adds 2 unique_ptrs to replace take ownership of them rather than leaving them as raw ptrs.