### PR TITLE
Add a safety margin buffer to collision evaluators

### DIFF
--- a/trajopt/include/trajopt/collision_terms.hpp
+++ b/trajopt/include/trajopt/collision_terms.hpp
@@ -37,7 +37,8 @@ struct CollisionEvaluator
                      const Eigen::Isometry3d& world_to_base,
                      SafetyMarginData::ConstPtr safety_margin_data,
                      tesseract_collision::ContactTestType contact_test_type,
-                     double longest_valid_segment_length);
+                     double longest_valid_segment_length,
+                     double safety_margin_buffer);
   virtual ~CollisionEvaluator() = default;
   CollisionEvaluator(const CollisionEvaluator&) = default;
   CollisionEvaluator& operator=(const CollisionEvaluator&) = default;
@@ -98,6 +99,7 @@ protected:
   tesseract_environment::AdjacencyMap::ConstPtr adjacency_map_;
   Eigen::Isometry3d world_to_base_;
   SafetyMarginData::ConstPtr safety_margin_data_;
+  double safety_margin_buffer_;
   tesseract_collision::ContactTestType contact_test_type_;
   double longest_valid_segment_length_;
   tesseract_environment::StateSolver::Ptr state_solver_;
@@ -160,7 +162,8 @@ public:
                                    const Eigen::Isometry3d& world_to_base,
                                    SafetyMarginData::ConstPtr safety_margin_data,
                                    tesseract_collision::ContactTestType contact_test_type,
-                                   sco::VarVector vars);
+                                   sco::VarVector vars,
+                                   double safety_margin_buffer);
   /**
   @brief linearize all contact distances in terms of robot dofs
   ;
@@ -193,7 +196,8 @@ public:
                          double longest_valid_segment_length,
                          sco::VarVector vars0,
                          sco::VarVector vars1,
-                         CollisionExpressionEvaluatorType type);
+                         CollisionExpressionEvaluatorType type,
+                         double safety_margin_buffer);
   void CalcDistExpressions(const DblVec& x, sco::AffExprVector& exprs) override;
   void CalcCollisions(const DblVec& x, tesseract_collision::ContactResultVector& dist_results) override;
   void Plot(const tesseract_visualization::Visualization::Ptr& plotter, const DblVec& x) override;
@@ -220,7 +224,8 @@ public:
                              double longest_valid_segment_length,
                              sco::VarVector vars0,
                              sco::VarVector vars1,
-                             CollisionExpressionEvaluatorType type);
+                             CollisionExpressionEvaluatorType type,
+                             double safety_margin_buffer);
   void CalcDistExpressions(const DblVec& x, sco::AffExprVector& exprs) override;
   void CalcCollisions(const DblVec& x, tesseract_collision::ContactResultVector& dist_results) override;
   void Plot(const tesseract_visualization::Visualization::Ptr& plotter, const DblVec& x) override;
@@ -241,7 +246,8 @@ public:
                 const Eigen::Isometry3d& world_to_base,
                 SafetyMarginData::ConstPtr safety_margin_data,
                 tesseract_collision::ContactTestType contact_test_type,
-                sco::VarVector vars);
+                sco::VarVector vars,
+                double safety_margin_buffer);
   /* constructor for discrete continuous and cast continuous cost */
   CollisionCost(tesseract_kinematics::ForwardKinematics::ConstPtr manip,
                 tesseract_environment::Environment::ConstPtr env,
@@ -253,7 +259,8 @@ public:
                 sco::VarVector vars0,
                 sco::VarVector vars1,
                 CollisionExpressionEvaluatorType type,
-                bool discrete);
+                bool discrete,
+                double safety_margin_buffer);
   sco::ConvexObjective::Ptr convex(const DblVec& x, sco::Model* model) override;
   double value(const DblVec&) override;
   void Plot(const tesseract_visualization::Visualization::Ptr& plotter, const DblVec& x) override;
@@ -273,7 +280,8 @@ public:
                       const Eigen::Isometry3d& world_to_base,
                       SafetyMarginData::ConstPtr safety_margin_data,
                       tesseract_collision::ContactTestType contact_test_type,
-                      sco::VarVector vars);
+                      sco::VarVector vars,
+                      double safety_margin_buffer);
   /* constructor for discrete continuous and cast continuous cost */
   CollisionConstraint(tesseract_kinematics::ForwardKinematics::ConstPtr manip,
                       tesseract_environment::Environment::ConstPtr env,
@@ -285,7 +293,8 @@ public:
                       sco::VarVector vars0,
                       sco::VarVector vars1,
                       CollisionExpressionEvaluatorType type,
-                      bool discrete);
+                      bool discrete,
+                      double safety_margin_buffer);
   sco::ConvexConstraints::Ptr convex(const DblVec& x, sco::Model* model) override;
   DblVec value(const DblVec&) override;
   void Plot(const DblVec& x);

--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -568,6 +568,11 @@ struct CollisionTermInfo : public TermInfo
    */
   double longest_valid_segment_length = 0.5;
 
+  /** @brief A buffer added to the collision margin distance. Contact results that are within the safety margin buffer distance but greater than the
+  safety margin distance (i.e. close but not in collision) will be evaluated but will not contribute costs to the optimization problem.
+  This helps keep the solution away from collision constraint conditions when the safety margin distance is small.*/
+  double safety_margin_buffer = 0.05;
+
   /** @brief Set the contact test type that should be used. */
   tesseract_collision::ContactTestType contact_test_type = tesseract_collision::ContactTestType::ALL;
 

--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -568,9 +568,10 @@ struct CollisionTermInfo : public TermInfo
    */
   double longest_valid_segment_length = 0.5;
 
-  /** @brief A buffer added to the collision margin distance. Contact results that are within the safety margin buffer distance but greater than the
-  safety margin distance (i.e. close but not in collision) will be evaluated but will not contribute costs to the optimization problem.
-  This helps keep the solution away from collision constraint conditions when the safety margin distance is small.*/
+  /** @brief A buffer added to the collision margin distance. Contact results that are within the safety margin buffer
+  distance but greater than the safety margin distance (i.e. close but not in collision) will be evaluated but will not
+  contribute costs to the optimization problem. This helps keep the solution away from collision constraint conditions
+  when the safety margin distance is small.*/
   double safety_margin_buffer = 0.05;
 
   /** @brief Set the contact test type that should be used. */

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -1549,10 +1549,13 @@ void CollisionTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value
   json_marshal::childFromJson(params, first_step, "first_step", 0);
   json_marshal::childFromJson(params, last_step, "last_step", n_steps - 1);
   json_marshal::childFromJson(params, longest_valid_segment_length, "longest_valid_segment_length", 0.5);
+  json_marshal::childFromJson(params, safety_margin_buffer, "safety_margin_buffer", 0.5);
+
   FAIL_IF_FALSE(longest_valid_segment_length >= 0);
   FAIL_IF_FALSE((first_step >= 0) && (first_step < n_steps));
   FAIL_IF_FALSE((last_step >= first_step) && (last_step < n_steps));
   FAIL_IF_FALSE(collision_evaluator_type <= 2);
+  FAIL_IF_FALSE(safety_margin_buffer >= 0);
 
   evaluator_type = static_cast<CollisionEvaluatorType>(collision_evaluator_type);
 
@@ -1719,7 +1722,8 @@ void CollisionTermInfo::hatch(TrajOptProb& prob)
                                                  prob.GetVarRow(i, 0, n_dof),
                                                  prob.GetVarRow(i + 1, 0, n_dof),
                                                  expression_evaluator_type,
-                                                 discrete_continuous);
+                                                 discrete_continuous,
+                                                 safety_margin_buffer);
 
         prob.addCost(c);
         prob.getCosts().back()->setName((boost::format("%s_%i") % name.c_str() % i).str());
@@ -1737,7 +1741,8 @@ void CollisionTermInfo::hatch(TrajOptProb& prob)
                                                    world_to_base,
                                                    info[static_cast<size_t>(i - first_step)],
                                                    contact_test_type,
-                                                   prob.GetVarRow(i, 0, n_dof));
+                                                   prob.GetVarRow(i, 0, n_dof),
+                                                   safety_margin_buffer);
           prob.addCost(c);
           prob.getCosts().back()->setName((boost::format("%s_%i") % name.c_str() % i).str());
         }
@@ -1782,7 +1787,8 @@ void CollisionTermInfo::hatch(TrajOptProb& prob)
                                                        prob.GetVarRow(i, 0, n_dof),
                                                        prob.GetVarRow(i + 1, 0, n_dof),
                                                        expression_evaluator_type,
-                                                       discrete_continuous);
+                                                       discrete_continuous,
+                                                       safety_margin_buffer);
 
         prob.addIneqConstraint(c);
         prob.getIneqConstraints().back()->setName((boost::format("%s_%i") % name.c_str() % i).str());
@@ -1800,7 +1806,8 @@ void CollisionTermInfo::hatch(TrajOptProb& prob)
                                                          world_to_base,
                                                          info[static_cast<size_t>(i - first_step)],
                                                          contact_test_type,
-                                                         prob.GetVarRow(i, 0, n_dof));
+                                                         prob.GetVarRow(i, 0, n_dof),
+                                                         safety_margin_buffer);
           prob.addIneqConstraint(c);
           prob.getIneqConstraints().back()->setName((boost::format("%s_%i") % name.c_str() % i).str());
         }

--- a/trajopt_sco/package.xml
+++ b/trajopt_sco/package.xml
@@ -9,6 +9,7 @@
   <depend>osqp</depend>
   <depend>trajopt_utils</depend>
   <depend>libjsoncpp-dev</depend>
+  <depend>osqp</depend>
 
   <test_depend>gtest</test_depend>
 

--- a/trajopt_sco/package.xml
+++ b/trajopt_sco/package.xml
@@ -9,7 +9,6 @@
   <depend>osqp</depend>
   <depend>trajopt_utils</depend>
   <depend>libjsoncpp-dev</depend>
-  <depend>osqp</depend>
 
   <test_depend>gtest</test_depend>
 

--- a/trajopt_sco/src/optimizers.cpp
+++ b/trajopt_sco/src/optimizers.cpp
@@ -682,6 +682,14 @@ OptStatus BasicTrustRegionSQP::optimize()
       {
         LOG_INFO("iteration limit");
         retval = OPT_SCO_ITERATION_LIMIT;
+
+        if (results_.cnt_viols.empty() || vecMax(results_.cnt_viols) < param_.cnt_tolerance)
+        {
+          retval = OPT_CONVERGED;
+          if (!results_.cnt_viols.empty())
+            LOG_INFO("woo-hoo! constraints are satisfied (to tolerance %.2e)", param_.cnt_tolerance);
+        }
+
         goto cleanup;
       }
     } /* sqp loop */


### PR DESCRIPTION
Adds a `safety_margin_buffer` parameter to the Trajopt collision evaluators. This is an additional buffer that is added to the safety margin when checking if contacts should be evaluated as collisions. Contact distances within `safety_margin + safety_margin_buffer` will be evaluated by the optimization but will not contribute a cost. The purpose of this change is to help the optimization stay out of collision when the safety margin distance is very small. The default value is set to 0.05m.

Other changes:
- Fix a missing OSQP dependency in `trajopt_sco`
- Fix a bug where the optimization would fail in cases when it actually converged with all constraints satisfied.