### PR TITLE
Improve efficiency of sparse matrix initialization

### DIFF
--- a/trajopt_sco/src/solver_utils.cpp
+++ b/trajopt_sco/src/solver_utils.cpp
@@ -90,8 +90,8 @@ void exprToEigen(const AffExprVector& expr_vec,
   sparse_matrix.resize(static_cast<long int>(expr_vec.size()), n_vars);
   sparse_matrix.reserve(static_cast<long int>(expr_vec.size()) * n_vars);
 
-  IntVec triplet_rows, triplet_cols;
-  DblVec triplet_values_row_col;
+  using T = Eigen::Triplet<double>;
+  std::vector<T, Eigen::aligned_allocator<T>> triplets;
 
   for (int i = 0; i < static_cast<int>(expr_vec.size()); ++i)
   {
@@ -109,13 +109,11 @@ void exprToEigen(const AffExprVector& expr_vec,
       }
       if (expr.coeffs[j] != 0.)
       {
-        triplet_rows.push_back(i);
-        triplet_cols.push_back(i_var_index);
-        triplet_values_row_col.push_back(expr.coeffs[j]);
+        triplets.emplace_back(i, i_var_index, expr.coeffs[j]);
       }
     }
   }
-  tripletsToEigen(triplet_rows, triplet_cols, triplet_values_row_col, sparse_matrix);
+  sparse_matrix.setFromTriplets(triplets.begin(), triplets.end());
 }
 
 void tripletsToEigen(const IntVec& rows_i,


### PR DESCRIPTION
Problem setup takes a very long time when the number of affine expressions is very large, for example if there are many link pairs that could be in collision and multiple costs or constraints are assigned per pair. I'd like to benchmark this more thoroughly, but as an example a problem with about 5000 variables and 10000 constraints took about 60s to set up and then about 1 second to solve.

The reason for this is that the function for composing Eigen sparse matrices from affine expression vectors uses a very inefficient method for inserting new elements. [According to the Eigen documentation](https://eigen.tuxfamily.org/dox/group__TutorialSparse.html), the `coeffRef` function performs a binary search on the matrix when inserting each new element to make sure that there is not already an element at the specified row and column. Additionally, the `exprToEigen` function composes a separate sparse vector for each row in the sparse matrix, which increases the number of calls to `coeffRef`. Since `coeffRef` is `O(log(n))` where `n` is the number of nonzero elements in each matrix row (from [here](https://eigen.tuxfamily.org/dox/classEigen_1_1SparseMatrix.html#title12)), creating a sparse matrix in this way with `n` rows and `m` elements per row is (I think):
```
O(n log(m) + n m log(m))
```

A better way to create a sparse matrix while ensuring good performance is to compose a list of triplets containing `[row, col, value]` and then convert that into a matrix using `setFromTriplets`, which is `O(n)` where `n` is the number of triplets (from [here](https://eigen.tuxfamily.org/dox/classEigen_1_1SparseMatrix.html#title35)). For a sparse matrix with `n` rows and `m` elements per row this would be:
```
O(n m)
```

This PR modifies the version of `exprToEigen` most frequently used by the OSQP interface to use triplets, which greatly reduces the setup time for large problems. In my example case, the problem can now be set up in less than 0.5s.