### PR TITLE
Add ability to use weighted sum jacobian calculation for contact link pairs

### DIFF
--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -557,6 +557,12 @@ struct CollisionTermInfo : public TermInfo
   /** @brief Indicate the type of collision checking that should be used. */
   CollisionEvaluatorType evaluator_type;
 
+  /**
+   * @brief Use the weighted sum for each link pair. This reduces the number equations added to the problem
+   * When enable it is good to start with a coefficient of 1 otherwise 20 is a good starting point.
+   */
+  bool use_weighted_sum = false;
+
   /** @brief Indicated if a step is fixed and its variables cannot be changed */
   std::vector<int> fixed_steps;
 

--- a/trajopt/include/trajopt/typedefs.hpp
+++ b/trajopt/include/trajopt/typedefs.hpp
@@ -22,6 +22,9 @@ using TrajArray = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::R
 using DblVec = sco::DblVec;
 using IntVec = sco::IntVec;
 
+template <typename T>
+using AlignedVector = std::vector<T, Eigen::aligned_allocator<T>>;
+
 template <typename Key, typename Value>
 using AlignedUnorderedMap = std::unordered_map<Key,
                                                Value,


### PR DESCRIPTION
The current implementation for the collision term added an equation for each contact results. This means for a given link pair it could have multiple contacts if the links contain multiple collision objections. This results in a large number of equation to solve for some environments. This enables the ability to use the weighted sum for a given link pair so you only end up with one equation per link pair significantly reducing the number of equations to solve.