### PR TITLE
Use std::move when calling addLink

### DIFF
--- a/trajopt/test/cast_cost_attached_unit.cpp
+++ b/trajopt/test/cast_cost_attached_unit.cpp
@@ -72,7 +72,7 @@ public:
     box_attached_joint.child_link_name = "box_attached";
     box_attached_joint.parent_to_joint_origin_transform.translation() = Eigen::Vector3d(0.5, -0.5, 0);
 
-    tesseract_->getEnvironment()->addLink(box_attached_link, box_attached_joint);
+    tesseract_->getEnvironment()->addLink(std::move(box_attached_link), std::move(box_attached_joint));
     tesseract_->getEnvironment()->setLinkCollisionEnabled("box_attached", false);
     tesseract_->getEnvironment()->addAllowedCollision("box_attached", "boxbot_link", "Adjacent");
 
@@ -85,7 +85,7 @@ public:
     box_attached2_joint.child_link_name = "box_attached2";
     box_attached2_joint.parent_to_joint_origin_transform.translation() = Eigen::Vector3d(0, 0, 0);
 
-    tesseract_->getEnvironment()->addLink(box_attached2_link, box_attached2_joint);
+    tesseract_->getEnvironment()->addLink(std::move(box_attached2_link), std::move(box_attached2_joint));
     tesseract_->getEnvironment()->setLinkCollisionEnabled("box_attached2", false);
     tesseract_->getEnvironment()->addAllowedCollision("box_attached2", "boxbot_link", "Adjacent");
   }

--- a/trajopt/test/cast_cost_octomap_unit.cpp
+++ b/trajopt/test/cast_cost_octomap_unit.cpp
@@ -89,7 +89,7 @@ public:
     new_joint.parent_link_name = "base_link";
     new_joint.child_link_name = "octomap_attached";
 
-    tesseract_->getEnvironment()->addLink(new_link, new_joint);
+    tesseract_->getEnvironment()->addLink(std::move(new_link), std::move(new_joint));
   }
 };
 

--- a/trajopt/test/cast_cost_world_unit.cpp
+++ b/trajopt/test/cast_cost_world_unit.cpp
@@ -72,7 +72,7 @@ public:
     new_joint.parent_link_name = "base_link";
     new_joint.child_link_name = "box_world";
 
-    tesseract_->getEnvironment()->addLink(new_link, new_joint);
+    tesseract_->getEnvironment()->addLink(std::move(new_link), std::move(new_joint));
 
     // TODO: Need to add method to environment to disable collision and hid objects
   }


### PR DESCRIPTION
The unit tests were broken in a recent Tesseract PR.