### PR TITLE
Changes for Gurobi compatibility with Ubuntu 18.04

### DIFF
--- a/trajopt_sco/include/trajopt_sco/solver_interface.hpp
+++ b/trajopt_sco/include/trajopt_sco/solver_interface.hpp
@@ -234,7 +234,11 @@ Model::Ptr createModel(ModelType model_type = ModelType::AUTO_SOLVER);
 
 SizeTVec vars2inds(const VarVector& vars);
 
+IntVec vars2indsI(const VarVector& vars);
+
 SizeTVec cnts2inds(const CntVector& cnts);
+
+IntVec cnts2indsI(const CntVector& cnts);
 
 /**
  * @brief simplify2 gets as input a list of indices, corresponding to non-zero

--- a/trajopt_sco/src/solver_interface.cpp
+++ b/trajopt_sco/src/solver_interface.cpp
@@ -20,9 +20,26 @@ SizeTVec vars2inds(const VarVector& vars)
     inds[i] = vars[i].var_rep->index;
   return inds;
 }
+
+IntVec vars2indsI(const VarVector& vars)
+{
+  IntVec inds(vars.size());
+  for (size_t i = 0; i < inds.size(); ++i)
+    inds[i] = vars[i].var_rep->index;
+  return inds;
+}
+
 SizeTVec cnts2inds(const CntVector& cnts)
 {
   SizeTVec inds(cnts.size());
+  for (size_t i = 0; i < inds.size(); ++i)
+    inds[i] = cnts[i].cnt_rep->index;
+  return inds;
+}
+
+IntVec cnts2indsI(const CntVector& cnts)
+{
+  IntVec inds(cnts.size());
   for (size_t i = 0; i < inds.size(); ++i)
     inds[i] = cnts[i].cnt_rep->index;
   return inds;


### PR DESCRIPTION
vars is of type sco::SizeTVec which is std::vector of type "long unsigned int"
IntVec is of type sco::IntVec which is std::vector of type "int"

Auto conversion not working with Gurobi on Ubumtu 18.04