### PR TITLE
Collision Interpolation Bug Fix

### DIFF
--- a/trajopt/src/collision_terms.cpp
+++ b/trajopt/src/collision_terms.cpp
@@ -879,32 +879,22 @@ void CollisionEvaluator::processInterpolatedCollisionResults(
       // Update cc_time and cc_type
       for (auto& r : pair.second)
       {
-        if (std::find(active_links.begin(), active_links.end(), r.link_names[0]) != active_links.end())
+        // Iterate over the two time values in r.cc_time
+        for (size_t j = 0; j < 2; ++j)
         {
-          r.cc_time[0] =
-              (r.cc_time[0] < 0) ? (static_cast<double>(i) * dt) : (static_cast<double>(i) * dt) + (r.cc_time[0] * dt);
-          assert(r.cc_time[0] >= 0.0 && r.cc_time[0] <= 1.0);
-          if (i == 0 && r.cc_type[0] == tesseract_collision::ContinuousCollisionType::CCType_Time0)
-            r.cc_type[0] = tesseract_collision::ContinuousCollisionType::CCType_Time0;
-          else if (i == (contacts_vector.size() - 1) &&
-                   r.cc_type[0] == tesseract_collision::ContinuousCollisionType::CCType_Time1)
-            r.cc_type[0] = tesseract_collision::ContinuousCollisionType::CCType_Time1;
-          else
-            r.cc_type[0] = tesseract_collision::ContinuousCollisionType::CCType_Between;
-        }
-
-        if (std::find(active_links.begin(), active_links.end(), r.link_names[1]) != active_links.end())
-        {
-          r.cc_time[1] =
-              (r.cc_time[0] < 0) ? (static_cast<double>(i) * dt) : (static_cast<double>(i) * dt) + (r.cc_time[1] * dt);
-          assert(r.cc_time[1] >= 0.0 && r.cc_time[1] <= 1.0);
-          if (i == 0 && r.cc_type[1] == tesseract_collision::ContinuousCollisionType::CCType_Time0)
-            r.cc_type[1] = tesseract_collision::ContinuousCollisionType::CCType_Time0;
-          else if (i == (contacts_vector.size() - 1) &&
-                   r.cc_type[1] == tesseract_collision::ContinuousCollisionType::CCType_Time1)
-            r.cc_type[1] = tesseract_collision::ContinuousCollisionType::CCType_Time1;
-          else
-            r.cc_type[1] = tesseract_collision::ContinuousCollisionType::CCType_Between;
+          if (std::find(active_links.begin(), active_links.end(), r.link_names[j]) != active_links.end())
+          {
+            r.cc_time[j] = (r.cc_time[j] < 0) ? (static_cast<double>(i) * dt) :
+                                                (static_cast<double>(i) * dt) + (r.cc_time[j] * dt);
+            assert(r.cc_time[j] >= 0.0 && r.cc_time[j] <= 1.0);
+            if (i == 0 && r.cc_type[j] == tesseract_collision::ContinuousCollisionType::CCType_Time0)
+              r.cc_type[j] = tesseract_collision::ContinuousCollisionType::CCType_Time0;
+            else if (i == (contacts_vector.size() - 1) &&
+                     r.cc_type[j] == tesseract_collision::ContinuousCollisionType::CCType_Time1)
+              r.cc_type[j] = tesseract_collision::ContinuousCollisionType::CCType_Time1;
+            else
+              r.cc_type[j] = tesseract_collision::ContinuousCollisionType::CCType_Between;
+          }
         }
       }
 

--- a/trajopt/test/planning_unit.cpp
+++ b/trajopt/test/planning_unit.cpp
@@ -143,7 +143,7 @@ TEST_F(PlanningTest, arm_around_table)  // NOLINT
 
   ProblemConstructionInfo pci(tesseract_);
   pci.fromJson(root);
-  pci.basic_info.convex_solver = sco::ModelType::BPMPD;
+  pci.basic_info.convex_solver = sco::ModelType::OSQP;
   TrajOptProb::Ptr prob = ConstructProblem(pci);
   ASSERT_TRUE(!!prob);
 

--- a/trajopt/test/planning_unit.cpp
+++ b/trajopt/test/planning_unit.cpp
@@ -141,7 +141,10 @@ TEST_F(PlanningTest, arm_around_table)  // NOLINT
 
   //  plotter_->plotScene();
 
-  TrajOptProb::Ptr prob = ConstructProblem(root, tesseract_);
+  ProblemConstructionInfo pci(tesseract_);
+  pci.fromJson(root);
+  pci.basic_info.convex_solver = sco::ModelType::BPMPD;
+  TrajOptProb::Ptr prob = ConstructProblem(pci);
   ASSERT_TRUE(!!prob);
 
   std::vector<ContactResultMap> collisions;

--- a/trajopt_sco/src/osqp_interface.cpp
+++ b/trajopt_sco/src/osqp_interface.cpp
@@ -33,6 +33,7 @@ OSQPModel::OSQPModel() : P_(nullptr), A_(nullptr)
   osqp_settings_.max_iter = 8192;
   osqp_settings_.polish = 1;
   osqp_settings_.verbose = false;
+  osqp_settings_.adaptive_rho = false;
 }
 OSQPModel::~OSQPModel()
 {


### PR DESCRIPTION
This PR fixes a bug where the `cc_time` of the second link in a collision pair was being indexed incorrectly. It also replaces code with for loop since the same operations are applied to both collision links