### PR TITLE
Fixes for Gurobi 9.0.1

### DIFF
--- a/trajopt_sco/CMakeLists.txt
+++ b/trajopt_sco/CMakeLists.txt
@@ -66,7 +66,7 @@ add_library(${PROJECT_NAME} SHARED ${SCO_SOURCE_FILES})
 
 if (GUROBI_FOUND)
   target_link_libraries(${PROJECT_NAME} PRIVATE ${GUROBI_LIBRARIES})
-  target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${GUROBI_INCLUDE_DIR})
+  target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${GUROBI_INCLUDE_DIRS})
   target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_GUROBI=ON)
 endif()
 if (HAVE_BPMPD)

--- a/trajopt_sco/cmake/FindGUROBI.cmake
+++ b/trajopt_sco/cmake/FindGUROBI.cmake
@@ -4,40 +4,32 @@
 # environment variables:
 # GUROBI_HOME
 # 
-# e.g. GUROBI_HOME=/opt/gurobobi810/linux64
+# e.g. GUROBI_HOME=/opt/gurobi901/linux64
 #
 # The module will define:
 # GUROBI_FOUND - If we found Gurobi in the system
-# GUROBI_INCLUDE_DIR - Gurobi include directories
+# GUROBI_INCLUDE_DIRS - Gurobi include directories
 # GUROBI_LIBRARIES - libraries needed to use Gurobi
 #
 # This module will NOT enforce a specific GUROBI version, rather it will
-# only work with latest GUROBI version (8.1.0)
+# only work with latest GUROBI versions (8.1.0 and 9.0)
 
-find_path(GUROBI_INCLUDE_DIR NAMES gurobi_c++.h
-          HINTS
-          ENV GUROBI_HOME
-          PATH_SUFFIXES include
-          )
+find_path(GUROBI_INCLUDE_DIRS
+    NAMES gurobi_c.h
+    HINTS ${GUROBI_DIR} $ENV{GUROBI_HOME}
+    PATH_SUFFIXES include)
 
-find_library(GUROBI_LIBRARY NAMES gurobi81
-             HINTS
-             ENV GUROBI_HOME
-             PATH_SUFFIXES lib
-             )
+find_library(GUROBI_LIBRARY
+    NAMES gurobi gurobi81 gurobi90
+    HINTS ${GUROBI_DIR} $ENV{GUROBI_HOME}
+    PATH_SUFFIXES lib)
 
-find_library(GUROBI_CXX_LIBRARY NAMES gurobi_c++
-             HINTS
-             ENV GUROBI_HOME
-             PATH_SUFFIXES lib
-             )
-
-set(GUROBI_LIBRARIES  ${GUROBI_LIBRARY} ${GUROBI_CXX_LIBRARY})
+set(GUROBI_LIBRARIES ${GUROBI_LIBRARY})
 
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set GUROBI_FOUND to TRUE
 # if all listed variables are TRUE
 find_package_handle_standard_args(GUROBI  DEFAULT_MSG
-                                  GUROBI_LIBRARY GUROBI_CXX_LIBRARY GUROBI_INCLUDE_DIR)
+                                  GUROBI_LIBRARY GUROBI_INCLUDE_DIRS)
 
-mark_as_advanced(GUROBI_INCLUDE_DIR GUROBI_LIBRARY GUROBI_CXX_LIBRARY GUROBI_LIBRARIES)
+mark_as_advanced(GUROBI_INCLUDE_DIRS GUROBI_LIBRARY GUROBI_LIBRARIES)

--- a/trajopt_sco/include/trajopt_sco/solver_interface.hpp
+++ b/trajopt_sco/include/trajopt_sco/solver_interface.hpp
@@ -232,9 +232,9 @@ std::ostream& operator<<(std::ostream& os, const ModelType& cs);
 
 Model::Ptr createModel(ModelType model_type = ModelType::AUTO_SOLVER);
 
-void vars2inds(const VarVector& varsm, SizeTVec& inds);
+void vars2inds(const VarVector& vars, SizeTVec& inds);
 
-void vars2inds(const VarVector& varsm, IntVec& inds);
+void vars2inds(const VarVector& vars, IntVec& inds);
 
 void cnts2inds(const CntVector& cnts, SizeTVec& inds);
 

--- a/trajopt_sco/include/trajopt_sco/solver_interface.hpp
+++ b/trajopt_sco/include/trajopt_sco/solver_interface.hpp
@@ -232,9 +232,13 @@ std::ostream& operator<<(std::ostream& os, const ModelType& cs);
 
 Model::Ptr createModel(ModelType model_type = ModelType::AUTO_SOLVER);
 
-SizeTVec vars2inds(const VarVector& vars);
+void vars2inds(const VarVector& varsm, SizeTVec &inds);
 
-SizeTVec cnts2inds(const CntVector& cnts);
+void vars2inds(const VarVector& varsm, IntVec &inds);
+
+void cnts2inds(const CntVector& cnts, SizeTVec &inds);
+
+void cnts2inds(const CntVector& cnts, IntVec &inds);
 
 /**
  * @brief simplify2 gets as input a list of indices, corresponding to non-zero

--- a/trajopt_sco/include/trajopt_sco/solver_interface.hpp
+++ b/trajopt_sco/include/trajopt_sco/solver_interface.hpp
@@ -232,13 +232,13 @@ std::ostream& operator<<(std::ostream& os, const ModelType& cs);
 
 Model::Ptr createModel(ModelType model_type = ModelType::AUTO_SOLVER);
 
-void vars2inds(const VarVector& varsm, SizeTVec &inds);
+void vars2inds(const VarVector& varsm, SizeTVec& inds);
 
-void vars2inds(const VarVector& varsm, IntVec &inds);
+void vars2inds(const VarVector& varsm, IntVec& inds);
 
-void cnts2inds(const CntVector& cnts, SizeTVec &inds);
+void cnts2inds(const CntVector& cnts, SizeTVec& inds);
 
-void cnts2inds(const CntVector& cnts, IntVec &inds);
+void cnts2inds(const CntVector& cnts, IntVec& inds);
 
 /**
  * @brief simplify2 gets as input a list of indices, corresponding to non-zero

--- a/trajopt_sco/src/bpmpd_interface.cpp
+++ b/trajopt_sco/src/bpmpd_interface.cpp
@@ -261,14 +261,16 @@ Cnt BPMPDModel::addIneqCnt(const QuadExpr&, const std::string& /*name*/)
 }
 void BPMPDModel::removeVars(const VarVector& vars)
 {
-  SizeTVec inds = vars2inds(vars);
+  SizeTVec inds;
+  vars2inds(vars, inds);
   for (const auto& var : vars)
     var.var_rep->removed = true;
 }
 
 void BPMPDModel::removeCnts(const CntVector& cnts)
 {
-  SizeTVec inds = cnts2inds(cnts);
+  SizeTVec inds;
+  cnts2inds(cnts, inds);
   for (auto& cnt : cnts)
     cnt.cnt_rep->removed = true;
 }
@@ -371,7 +373,8 @@ CvxOptStatus BPMPDModel::optimize()
   {
     const AffExpr& aff = m_cntExprs[iCnt];
     // cout << "adding constraint " << aff << endl;
-    SizeTVec inds = vars2inds(aff.vars);
+    SizeTVec inds;
+    vars2inds(aff.vars, inds);
 
     for (size_t i = 0; i < aff.vars.size(); ++i)
     {

--- a/trajopt_sco/src/gurobi_interface.cpp
+++ b/trajopt_sco/src/gurobi_interface.cpp
@@ -120,8 +120,13 @@ Cnt GurobiModel::addIneqCnt(const AffExpr& expr, const std::string& name)
   vars2inds(expr.vars, inds);
   DblVec vals = expr.coeffs;
   simplify2(inds, vals);
-  ENSURE_SUCCESS(GRBaddconstr(
-      m_model, static_cast<int>(inds.size()), inds.data(), vals.data(), GRB_LESS_EQUAL, -expr.constant, const_cast<char*>(name.c_str())));
+  ENSURE_SUCCESS(GRBaddconstr(m_model,
+                              static_cast<int>(inds.size()),
+                              inds.data(),
+                              vals.data(),
+                              GRB_LESS_EQUAL,
+                              -expr.constant,
+                              const_cast<char*>(name.c_str())));
   m_cnts.push_back(new CntRep(m_cnts.size(), this));
   return m_cnts.back();
 }
@@ -191,10 +196,10 @@ void GurobiModel::setVarBounds(const VarVector& vars, const DblVec& lower, const
   assert(vars.size() == lower.size() && vars.size() == upper.size());
   IntVec inds;
   vars2inds(vars, inds);
-  ENSURE_SUCCESS(
-      GRBsetdblattrlist(m_model, GRB_DBL_ATTR_LB, static_cast<int>(inds.size()), inds.data(), const_cast<double*>(lower.data())));
-  ENSURE_SUCCESS(
-      GRBsetdblattrlist(m_model, GRB_DBL_ATTR_UB, static_cast<int>(inds.size()), inds.data(), const_cast<double*>(upper.data())));
+  ENSURE_SUCCESS(GRBsetdblattrlist(
+      m_model, GRB_DBL_ATTR_LB, static_cast<int>(inds.size()), inds.data(), const_cast<double*>(lower.data())));
+  ENSURE_SUCCESS(GRBsetdblattrlist(
+      m_model, GRB_DBL_ATTR_UB, static_cast<int>(inds.size()), inds.data(), const_cast<double*>(upper.data())));
 }
 
 #if 0

--- a/trajopt_sco/src/osqp_interface.cpp
+++ b/trajopt_sco/src/osqp_interface.cpp
@@ -73,14 +73,16 @@ Cnt OSQPModel::addIneqCnt(const QuadExpr&, const std::string& /*name*/)
 
 void OSQPModel::removeVars(const VarVector& vars)
 {
-  SizeTVec inds = vars2inds(vars);
+  SizeTVec inds;
+  vars2inds(vars, inds);
   for (auto& var : vars)
     var.var_rep->removed = true;
 }
 
 void OSQPModel::removeCnts(const CntVector& cnts)
 {
-  SizeTVec inds = cnts2inds(cnts);
+  SizeTVec inds;
+  cnts2inds(cnts, inds);
   for (auto& cnt : cnts)
     cnt.cnt_rep->removed = true;
 }

--- a/trajopt_sco/src/qpoases_interface.cpp
+++ b/trajopt_sco/src/qpoases_interface.cpp
@@ -68,14 +68,16 @@ Cnt qpOASESModel::addIneqCnt(const QuadExpr&, const std::string& /*name*/)
 
 void qpOASESModel::removeVars(const VarVector& vars)
 {
-  IntVec inds = vars2inds(vars);
+  IntVec inds;
+  vars2inds(vars, inds);
   for (unsigned i = 0; i < vars.size(); ++i)
     vars[i].var_rep->removed = true;
 }
 
 void qpOASESModel::removeCnts(const CntVector& cnts)
 {
-  IntVec inds = cnts2inds(cnts);
+  IntVec inds;
+  cnts2inds(cnts, inds);
   for (unsigned i = 0; i < cnts.size(); ++i)
     cnts[i].cnt_rep->removed = true;
 }

--- a/trajopt_sco/src/solver_interface.cpp
+++ b/trajopt_sco/src/solver_interface.cpp
@@ -13,28 +13,28 @@ namespace sco
 {
 const std::vector<std::string> ModelType::MODEL_NAMES_ = { "GUROBI", "BPMPD", "OSQP", "QPOASES", "AUTO_SOLVER" };
 
-void vars2inds(const VarVector& vars, SizeTVec &inds)
+void vars2inds(const VarVector& vars, SizeTVec& inds)
 {
   inds = SizeTVec(vars.size());
   for (size_t i = 0; i < inds.size(); ++i)
     inds[i] = vars[i].var_rep->index;
 }
 
-void vars2inds(const VarVector& vars, IntVec &inds)
+void vars2inds(const VarVector& vars, IntVec& inds)
 {
   inds = IntVec(vars.size());
   for (size_t i = 0; i < inds.size(); ++i)
     inds[i] = static_cast<int>(vars[i].var_rep->index);
 }
 
-void cnts2inds(const CntVector& cnts, SizeTVec &inds)
+void cnts2inds(const CntVector& cnts, SizeTVec& inds)
 {
   inds = SizeTVec(cnts.size());
   for (size_t i = 0; i < inds.size(); ++i)
     inds[i] = cnts[i].cnt_rep->index;
 }
 
-void cnts2inds(const CntVector& cnts, IntVec &inds)
+void cnts2inds(const CntVector& cnts, IntVec& inds)
 {
   inds = IntVec(cnts.size());
   for (size_t i = 0; i < inds.size(); ++i)

--- a/trajopt_sco/src/solver_interface.cpp
+++ b/trajopt_sco/src/solver_interface.cpp
@@ -24,7 +24,7 @@ void vars2inds(const VarVector& vars, IntVec &inds)
 {
   inds = IntVec(vars.size());
   for (size_t i = 0; i < inds.size(); ++i)
-    inds[i] = vars[i].var_rep->index;
+    inds[i] = static_cast<int>(vars[i].var_rep->index);
 }
 
 void cnts2inds(const CntVector& cnts, SizeTVec &inds)
@@ -38,7 +38,7 @@ void cnts2inds(const CntVector& cnts, IntVec &inds)
 {
   inds = IntVec(cnts.size());
   for (size_t i = 0; i < inds.size(); ++i)
-    inds[i] = cnts[i].cnt_rep->index;
+    inds[i] = static_cast<int>(cnts[i].cnt_rep->index);
 }
 
 void simplify2(IntVec& inds, DblVec& vals)

--- a/trajopt_sco/src/solver_interface.cpp
+++ b/trajopt_sco/src/solver_interface.cpp
@@ -13,19 +13,32 @@ namespace sco
 {
 const std::vector<std::string> ModelType::MODEL_NAMES_ = { "GUROBI", "BPMPD", "OSQP", "QPOASES", "AUTO_SOLVER" };
 
-SizeTVec vars2inds(const VarVector& vars)
+void vars2inds(const VarVector& vars, SizeTVec &inds)
 {
-  SizeTVec inds(vars.size());
+  inds = SizeTVec(vars.size());
   for (size_t i = 0; i < inds.size(); ++i)
     inds[i] = vars[i].var_rep->index;
-  return inds;
 }
-SizeTVec cnts2inds(const CntVector& cnts)
+
+void vars2inds(const VarVector& vars, IntVec &inds)
 {
-  SizeTVec inds(cnts.size());
+  inds = IntVec(vars.size());
+  for (size_t i = 0; i < inds.size(); ++i)
+    inds[i] = vars[i].var_rep->index;
+}
+
+void cnts2inds(const CntVector& cnts, SizeTVec &inds)
+{
+  inds = SizeTVec(cnts.size());
   for (size_t i = 0; i < inds.size(); ++i)
     inds[i] = cnts[i].cnt_rep->index;
-  return inds;
+}
+
+void cnts2inds(const CntVector& cnts, IntVec &inds)
+{
+  inds = IntVec(cnts.size());
+  for (size_t i = 0; i < inds.size(); ++i)
+    inds[i] = cnts[i].cnt_rep->index;
 }
 
 void simplify2(IntVec& inds, DblVec& vals)

--- a/trajopt_sco/src/solver_utils.cpp
+++ b/trajopt_sco/src/solver_utils.cpp
@@ -35,8 +35,10 @@ void exprToEigen(const QuadExpr& expr,
                  const bool& matrix_is_halved,
                  const bool& force_diagonal)
 {
-  SizeTVec ind1 = vars2inds(expr.vars1);
-  SizeTVec ind2 = vars2inds(expr.vars2);
+  SizeTVec ind1;
+  vars2inds(expr.vars1, ind1);
+  SizeTVec ind2;
+  vars2inds(expr.vars2, ind2);
   sparse_matrix.resize(n_vars, n_vars);
   sparse_matrix.reserve(static_cast<long int>(2 * expr.size()));
 


### PR DESCRIPTION
- Update `FindGUROBI.cmake` to find Gurobi 9.0 and to more generally match the example Gurobi provides [here](https://support.gurobi.com/hc/en-us/articles/360039499751-CMake-C-C-compilation-of-Gurobi-projects).
- Change the `vars2inds` and `cnts2inds` functions so they returns void and writes the output vector of indices to a parameter. Added new versions of these function that output a `SizeTVec`, which complements the existing functions that outputs a `IntVec`. This is a solution to the return type issue described in #168.
- Modify usages of these functions to reflect new return type and parameters.
- Add `static_cast`s where warnings were complaining about implicit conversions between types changing values.