### PR TITLE
Negative safety margin data

### DIFF
--- a/trajopt/include/trajopt/utils.hpp
+++ b/trajopt/include/trajopt/utils.hpp
@@ -60,6 +60,7 @@ struct SafetyMarginData
     : default_safety_margin_data_(default_safety_margin, default_safety_margin_coeff)
     , max_safety_margin_(default_safety_margin)
   {
+    negative_collisions_ = (default_safety_margin < 0) ? true : false;
   }
 
   /**
@@ -88,6 +89,7 @@ struct SafetyMarginData
     {
       max_safety_margin_ = safety_margin;
     }
+    negative_collisions_ = (safety_margin < 0) ? true : false;
   }
 
   /**
@@ -121,6 +123,15 @@ struct SafetyMarginData
    */
   const double& getMaxSafetyMargin() const { return max_safety_margin_; }
 
+  /**
+   * @brief Get if there are negative collisions allowed
+   *
+   * This used when checking if a more refined collision check is required.
+   *
+   * @return negative collisions allowed bool
+   */
+  const bool& getNegativeCollisions() const { return negative_collisions_; }
+
 private:
   /// The coeff used during optimization
   /// safety margin: contacts with distance < dist_pen are penalized
@@ -130,6 +141,9 @@ private:
   /// This use when requesting collision data because you can only provide a
   /// single contact distance threshold.
   double max_safety_margin_;
+
+  // This is used to check if there are negative collisions allowed
+  bool negative_collisions_ = false;
 
   /// A map of link pair to contact distance setting [dist_pen, coeff]
   AlignedUnorderedMap<std::string, Eigen::Vector2d> pair_lookup_table_;

--- a/trajopt/include/trajopt/utils.hpp
+++ b/trajopt/include/trajopt/utils.hpp
@@ -130,7 +130,7 @@ struct SafetyMarginData
    *
    * @return negative collisions allowed bool
    */
-  const bool& getNegativeCollisions() const { return negative_collisions_; }
+  const bool& hasNegativeCollisions() const { return negative_collisions_; }
 
 private:
   /// The coeff used during optimization
@@ -142,7 +142,7 @@ private:
   /// single contact distance threshold.
   double max_safety_margin_;
 
-  // This is used to check if there are negative collisions allowed
+  /// This is used to check if there are negative collisions allowed
   bool negative_collisions_ = false;
 
   /// A map of link pair to contact distance setting [dist_pen, coeff]

--- a/trajopt/include/trajopt/utils.hpp
+++ b/trajopt/include/trajopt/utils.hpp
@@ -89,7 +89,7 @@ struct SafetyMarginData
     {
       max_safety_margin_ = safety_margin;
     }
-    negative_collisions_ = (safety_margin < 0) ? true : false;
+    negative_collisions_ = (safety_margin < 0) ? true : negative_collisions_;
   }
 
   /**


### PR DESCRIPTION
This relates to [tesseract PR 259](https://github.com/ros-industrial-consortium/tesseract/pull/259). Giving the ability to check if there are any negative collision distances set in a `trajopt::SafetyMarginData`