### PR TITLE
Add CalcCollisions that takes only joint values instead of Vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,19 @@ The puzzle piece examples show a small collaborative robot manipulaing a puzzle 
 ![Puzzle Piece](gh_pages/_static/example_gifs/puzzle_piece.gif)  ![Puzzle Piece Aux Axes](gh_pages/_static/example_gifs/puzzle_piece_with_positioner.gif)
 
 
+## Building with Clang-Tidy Enabled
 
+Must pass the -DTRAJOPT_ENABLE_CLANG_TIDY=ON to cmake when building. This is automatically enabled if cmake argument -DTRAJOPT_ENABLE_CLANG_TIDY=ON is passed.
+
+## Building TrajOpt Tests
+
+Must pass the -DTRAJOPT_ENABLE_TESTING=ON to cmake when wanting to build tests. This is automatically enabled if cmake argument -DTRAJOPT_ENABLE_TESTING_ALL=ON is passed.
+
+.. NOTE: If you are building using catkin tools, use `catkin build --force-cmake -DTRAJOPT_ENABLE_TESTING=ON`.
+
+## Running TrajOpt Tests
+
+TrajOpt packages use ctest because it is ROS agnostic, so to run the test call `catkin test --no-deps trajopt trajopt_sco`
 
 
 ## Build Branch Sphinx Documentation

--- a/trajopt/include/trajopt/collision_terms.hpp
+++ b/trajopt/include/trajopt/collision_terms.hpp
@@ -389,6 +389,12 @@ public:
                            sco::AffExprVector& exprs,
                            AlignedVector<Eigen::Vector2d>& exprs_data) override;
   void CalcCollisions(const DblVec& x, tesseract_collision::ContactResultMap& dist_results) override;
+  /**
+   * @brief Given joint names and values calculate the collision results for this evaluator
+   * @param dof_vals Joint values set prior to collision checking
+   * @param dist_results Contact Results Map
+   */
+  void CalcCollisions(const Eigen::Ref<Eigen::VectorXd>& dof_vals, tesseract_collision::ContactResultMap& dist_results);
   void Plot(const tesseract_visualization::Visualization::Ptr& plotter, const DblVec& x) override;
   sco::VarVector GetVars() override { return vars0_; }
 
@@ -419,6 +425,15 @@ public:
                            sco::AffExprVector& exprs,
                            AlignedVector<Eigen::Vector2d>& exprs_data) override;
   void CalcCollisions(const DblVec& x, tesseract_collision::ContactResultMap& dist_results) override;
+  /**
+   * @brief Given joint names and values calculate the collision results for this evaluator
+   * @param dof_vals0 Joint values for state0
+   * @param dof_vals1 Joint values for state1
+   * @param dist_results Contact Results Map
+   */
+  void CalcCollisions(const Eigen::Ref<Eigen::VectorXd>& dof_vals0,
+                      const Eigen::Ref<Eigen::VectorXd>& dof_vals1,
+                      tesseract_collision::ContactResultMap& dist_results);
   void Plot(const tesseract_visualization::Visualization::Ptr& plotter, const DblVec& x) override;
   sco::VarVector GetVars() override { return concat(vars0_, vars1_); }
 
@@ -449,6 +464,15 @@ public:
                            sco::AffExprVector& exprs,
                            AlignedVector<Eigen::Vector2d>& exprs_data) override;
   void CalcCollisions(const DblVec& x, tesseract_collision::ContactResultMap& dist_results) override;
+  /**
+   * @brief Given joint names and values calculate the collision results for this evaluator
+   * @param dof_vals0 Joint values for state0
+   * @param dof_vals1 Joint values for state1
+   * @param dist_results Contact Results Map
+   */
+  void CalcCollisions(const Eigen::Ref<Eigen::VectorXd>& dof_vals0,
+                      const Eigen::Ref<Eigen::VectorXd>& dof_vals1,
+                      tesseract_collision::ContactResultMap& dist_results);
   void Plot(const tesseract_visualization::Visualization::Ptr& plotter, const DblVec& x) override;
   sco::VarVector GetVars() override { return concat(vars0_, vars1_); }
 

--- a/trajopt_utils/cmake/trajopt_macros.cmake
+++ b/trajopt_utils/cmake/trajopt_macros.cmake
@@ -82,7 +82,7 @@ macro(trajopt_target_compile_options target)
   endif()
 endmacro()
 
-# Add clang-tidy to a target if ENABLE_CLANG_TIDY or ENABLE_TESTS is enabled
+# Add clang-tidy to a target if TRAJOPT_ENABLE_CLANG_TIDY or TRAJOPT_ENABLE_TESTING is enabled
 # Usage: tesseract_clang_tidy(Target) or tesseract_clang_tidy(Target true) or tesseract_clang_tidy(Target false)
 #    * tesseract_clang_tidy(Target) adds clang tidy with warnings as errors
 #    * tesseract_clang_tidy(Target true) adds clang tidy with warnings as errors


### PR DESCRIPTION
This adds CalcCollision functions to the TrajOpt collision evaluators that take only Eigen types. This allows them to be used outside of the current Trajopt setup (and independently of Vars). Note that the constructor still requires that a VarVector be passed in (it can be empty if using the evaluator this way). We may want to revisit this with a more comprehensive refactor if we ever pursue something like IFOPT to break the dependency on sco.