### PR TITLE
Add Joint Term Benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,12 @@ env:
 matrix:
   include:
     - env: ROS_DISTRO=melodic CLANG_FORMAT_CHECK=file CLANG_FORMAT_VERSION=8 AFTER_SCRIPT=""
-    - env: ROS_DISTRO=kinetic DOCKER_IMAGE=lharmstrong/tesseract:kinetic
-    - env: ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed DOCKER_IMAGE=lharmstrong/tesseract:kinetic
+    - env: ROS_DISTRO=kinetic DOCKER_IMAGE=lharmstrong/tesseract:kinetic ROSDEP_SKIP_KEYS="bullet3 fcl benchmark"
+    - env: ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed DOCKER_IMAGE=lharmstrong/tesseract:kinetic ROSDEP_SKIP_KEYS="bullet3 fcl benchmark"
     - env: ROS_DISTRO=melodic DOCKER_IMAGE=lharmstrong/tesseract:melodic ROS_PARALLEL_JOBS=-j4 ROS_PARALLEL_TEST_JOBS=-j4
     - env: ROS_DISTRO=melodic ROS_REPO=ros-shadow-fixed DOCKER_IMAGE=lharmstrong/tesseract:melodic ROS_PARALLEL_JOBS=-j4 ROS_PARALLEL_TEST_JOBS=-j4
   allow_failures:
-    - env: ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed DOCKER_IMAGE=lharmstrong/tesseract:kinetic
+    - env: ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed DOCKER_IMAGE=lharmstrong/tesseract:kinetic ROSDEP_SKIP_KEYS="bullet3 fcl benchmark"
     - env: ROS_DISTRO=melodic ROS_REPO=ros-shadow-fixed DOCKER_IMAGE=lharmstrong/tesseract:melodic ROS_PARALLEL_JOBS=-j4 ROS_PARALLEL_TEST_JOBS=-j4
 
 install:

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ Must pass the -DTRAJOPT_ENABLE_TESTING=ON to cmake when wanting to build tests. 
 
 TrajOpt packages use ctest because it is ROS agnostic, so to run the test call `catkin test --no-deps trajopt trajopt_sco`
 
+## TrajOpt Benchmarks
+
+TrajOpt's Google benchmarks can be built by building with the flag `DTRAJOPT_ENABLE_BENCHMARKING=ON`.
+
+To run the benchmarks at compile time and save the results to a json file in the build directory, add the flag `-DTRAJOPT_ENABLE_RUN_BENCHMARKING=ON`
 
 ## Build Branch Sphinx Documentation
 

--- a/trajopt/CMakeLists.txt
+++ b/trajopt/CMakeLists.txt
@@ -60,7 +60,6 @@ if (TRAJOPT_ENABLE_TESTING)
 endif()
 
 if (TRAJOPT_ENABLE_BENCHMARKING)
-#  trajopt_add_run_benchmarks_target()
   add_subdirectory(test/benchmarks)
 endif()
 

--- a/trajopt/CMakeLists.txt
+++ b/trajopt/CMakeLists.txt
@@ -58,3 +58,9 @@ if (TRAJOPT_ENABLE_TESTING)
   trajopt_add_run_tests_target()
   add_subdirectory(test)
 endif()
+
+if (TRAJOPT_ENABLE_BENCHMARKING)
+#  trajopt_add_run_benchmarks_target()
+  add_subdirectory(test/benchmarks)
+endif()
+

--- a/trajopt/package.xml
+++ b/trajopt/package.xml
@@ -19,6 +19,7 @@
   <depend>tesseract</depend>
   <depend>tesseract_visualization</depend>
 
+  <test_depend>benchmark</test_depend>
   <test_depend>gtest</test_depend>
   <test_depend>libpcl-all-dev</test_depend>
 

--- a/trajopt/test/benchmarks/CMakeLists.txt
+++ b/trajopt/test/benchmarks/CMakeLists.txt
@@ -1,0 +1,23 @@
+find_package(benchmark REQUIRED)
+find_package(osqp REQUIRED)
+
+macro(add_benchmark benchmark_name benchmark_file)
+  add_executable(${benchmark_name} ${benchmark_file})
+  trajopt_target_compile_options(${benchmark_name} PRIVATE)
+  trajopt_clang_tidy(${benchmark_name})
+  target_compile_definitions(${benchmark_name} PRIVATE TRAJOPT_DIR="${CMAKE_SOURCE_DIR}")
+  target_link_libraries(${benchmark_name}
+      ${PROJECT_NAME}
+      tesseract::tesseract
+      osqp::osqpstatic
+      benchmark::benchmark
+      )
+  target_include_directories(${benchmark_name} PRIVATE
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
+  add_dependencies(${benchmark_name} ${PROJECT_NAME})
+#  add_dependencies(run_benchmarks ${benchmark_name})
+endmacro()
+
+add_benchmark(${PROJECT_NAME}_joint_term_benchmarks joint_term_benchmarks.cpp)
+
+

--- a/trajopt/test/benchmarks/CMakeLists.txt
+++ b/trajopt/test/benchmarks/CMakeLists.txt
@@ -15,9 +15,7 @@ macro(add_benchmark benchmark_name benchmark_file)
   target_include_directories(${benchmark_name} PRIVATE
       "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
   add_dependencies(${benchmark_name} ${PROJECT_NAME})
-#  add_dependencies(run_benchmarks ${benchmark_name})
+  trajopt_add_run_benchmark_target(${benchmark_name})
 endmacro()
 
 add_benchmark(${PROJECT_NAME}_joint_term_benchmarks joint_term_benchmarks.cpp)
-
-

--- a/trajopt/test/benchmarks/joint_term_benchmarks.cpp
+++ b/trajopt/test/benchmarks/joint_term_benchmarks.cpp
@@ -1,0 +1,207 @@
+#include <benchmark/benchmark.h>
+#include <iostream>
+
+#include <Eigen/Eigen>
+#include <trajopt/typedefs.hpp>
+#include <trajopt/trajectory_costs.hpp>
+#include <trajopt_sco/osqp_interface.hpp>
+
+/**
+ * @brief Creates a VarArray based on the model passed in
+ * @param model - Model that will store the varReps for the vars in the VarArray
+ * @param num_rows - Number of rows in the VarArray
+ * @param num_cols - Number of columns in the VarArray
+ * @return
+ */
+inline trajopt::VarArray createVarArray(std::shared_ptr<sco::OSQPModel>& model,
+                                        const int& num_rows,
+                                        const int& num_cols)
+{
+  trajopt::VarArray output;
+
+  for (int ind = 0; ind < num_rows; ind++)
+  {
+    for (int ind2 = 0; ind2 < num_cols; ind2++)
+    {
+      std::string name = std::to_string(ind) + "_" + std::to_string(ind2);
+      model->addVar(name);
+
+      // Copy in VarVector
+      output.m_data = model->getVars();
+      // Set rows and columns
+      output.m_nRow = num_rows;
+      output.m_nCol = num_cols;
+    }
+  }
+  return output;
+}
+
+/**
+ * @brief Contains information used to construct the terms
+ *
+ * Note: It is probably possible to make these templated fixture benchmarks in the future.
+ */
+class BenchmarkInfo
+{
+public:
+  BenchmarkInfo(int num_rows, int num_cols) : num_rows_(num_rows), num_cols_(num_cols)
+  {
+    coeffs = Eigen::VectorXd::Ones(num_cols_);
+    targets = Eigen::VectorXd::Zero(num_cols_);
+    upper = Eigen::VectorXd::Ones(num_cols_) * 0.5;
+    lower = Eigen::VectorXd::Ones(num_cols_) * -0.5;
+    first_step = 0;
+    last_step = num_rows_ - 1;
+    model = std::make_shared<sco::OSQPModel>();
+    traj = createVarArray(model, num_rows_, num_cols_);
+
+    trajopt::TrajArray traj_array = trajopt::TrajArray::Random(num_rows_, num_cols_);
+    dbl_vec = trajopt::DblVec(traj_array.data(), traj_array.data() + traj_array.rows() * traj_array.cols());
+  }
+  Eigen::VectorXd coeffs;
+  Eigen::VectorXd targets;
+  Eigen::VectorXd upper;
+  Eigen::VectorXd lower;
+  int first_step;
+  int last_step;
+  std::shared_ptr<sco::OSQPModel> model;
+  trajopt::VarArray traj;
+  trajopt::DblVec dbl_vec;
+
+private:
+  int num_rows_;
+  int num_cols_;
+};
+
+/** @brief Benchmark that tests the construction time of equality costs/cnts*/
+template <class CostClass>
+void BM_EQ_TERM_CONSTRUCTION(benchmark::State& state)
+{
+  BenchmarkInfo info(10, 6);
+
+  for (auto _ : state)
+  {
+    CostClass object(info.traj, info.coeffs, info.targets, info.first_step, info.last_step);
+  }
+}
+
+BENCHMARK_TEMPLATE(BM_EQ_TERM_CONSTRUCTION, trajopt::JointPosEqCost)->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_CONSTRUCTION, trajopt::JointVelEqCost)->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_CONSTRUCTION, trajopt::JointAccEqCost)->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_CONSTRUCTION, trajopt::JointJerkEqCost)->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_CONSTRUCTION, trajopt::JointPosEqConstraint)->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_CONSTRUCTION, trajopt::JointVelEqConstraint)->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_CONSTRUCTION, trajopt::JointAccEqConstraint)->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_CONSTRUCTION, trajopt::JointJerkEqConstraint)->Unit(benchmark::TimeUnit::kMicrosecond);
+
+/** @brief Benchmark that tests the construction time of inequality costs/cnts*/
+template <class CostClass>
+void BM_INEQ_TERM_CONSTRUCTION(benchmark::State& state)
+{
+  BenchmarkInfo info(10, 6);
+
+  for (auto _ : state)
+  {
+    CostClass object(info.traj, info.coeffs, info.targets, info.upper, info.lower, info.first_step, info.last_step);
+  }
+}
+
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_CONSTRUCTION, trajopt::JointPosIneqCost)->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_CONSTRUCTION, trajopt::JointVelIneqCost)->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_CONSTRUCTION, trajopt::JointAccIneqCost)->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_CONSTRUCTION, trajopt::JointJerkIneqCost)->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_CONSTRUCTION, trajopt::JointPosIneqConstraint)->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_CONSTRUCTION, trajopt::JointVelIneqConstraint)->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_CONSTRUCTION, trajopt::JointAccIneqConstraint)->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_CONSTRUCTION, trajopt::JointJerkIneqConstraint)
+    ->Unit(benchmark::TimeUnit::kMicrosecond);
+
+/** @brief Benchmark that tests the exact evaluation time of equality costs/cnts*/
+template <class CostClass>
+void BM_EQ_TERM_VALUE(benchmark::State& state)
+{
+  BenchmarkInfo info(10, 6);
+  CostClass object(info.traj, info.coeffs, info.targets, info.first_step, info.last_step);
+
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(object.value(info.dbl_vec));
+  }
+}
+
+BENCHMARK_TEMPLATE(BM_EQ_TERM_VALUE, trajopt::JointPosEqCost)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_VALUE, trajopt::JointVelEqCost)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_VALUE, trajopt::JointAccEqCost)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_VALUE, trajopt::JointJerkEqCost)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_VALUE, trajopt::JointPosEqConstraint)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_VALUE, trajopt::JointVelEqConstraint)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_VALUE, trajopt::JointAccEqConstraint)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_VALUE, trajopt::JointJerkEqConstraint)->Unit(benchmark::TimeUnit::kNanosecond);
+
+/** @brief Benchmark that tests the exact evaluation time of inequality costs/cnts*/
+template <class CostClass>
+void BM_INEQ_TERM_VALUE(benchmark::State& state)
+{
+  BenchmarkInfo info(10, 6);
+  CostClass object(info.traj, info.coeffs, info.targets, info.upper, info.lower, info.first_step, info.last_step);
+
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(object.value(info.dbl_vec));
+  }
+}
+
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_VALUE, trajopt::JointPosIneqCost)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_VALUE, trajopt::JointVelIneqCost)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_VALUE, trajopt::JointAccIneqCost)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_VALUE, trajopt::JointJerkIneqCost)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_VALUE, trajopt::JointPosIneqConstraint)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_VALUE, trajopt::JointVelIneqConstraint)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_VALUE, trajopt::JointAccIneqConstraint)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_VALUE, trajopt::JointJerkIneqConstraint)->Unit(benchmark::TimeUnit::kNanosecond);
+
+/** @brief Benchmark that tests the convex conversion time of equality costs/cnts*/
+template <class CostClass>
+void BM_EQ_TERM_CONVEX(benchmark::State& state)
+{
+  BenchmarkInfo info(10, 6);
+  CostClass object(info.traj, info.coeffs, info.targets, info.first_step, info.last_step);
+
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(object.convex(info.dbl_vec, info.model.get()));
+  }
+}
+
+BENCHMARK_TEMPLATE(BM_EQ_TERM_CONVEX, trajopt::JointPosEqCost)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_CONVEX, trajopt::JointVelEqCost)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_CONVEX, trajopt::JointAccEqCost)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_CONVEX, trajopt::JointJerkEqCost)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_CONVEX, trajopt::JointPosEqConstraint)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_CONVEX, trajopt::JointVelEqConstraint)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_CONVEX, trajopt::JointAccEqConstraint)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_EQ_TERM_CONVEX, trajopt::JointJerkEqConstraint)->Unit(benchmark::TimeUnit::kNanosecond);
+
+/** @brief Benchmark that tests the convex conversion time of equality costs/cnts*/
+template <class CostClass>
+void BM_INEQ_TERM_CONVEX(benchmark::State& state)
+{
+  BenchmarkInfo info(10, 6);
+  CostClass object(info.traj, info.coeffs, info.targets, info.upper, info.lower, info.first_step, info.last_step);
+
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(object.convex(info.dbl_vec, info.model.get()));
+  }
+}
+
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_CONVEX, trajopt::JointPosIneqCost)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_CONVEX, trajopt::JointVelIneqCost)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_CONVEX, trajopt::JointAccIneqCost)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_CONVEX, trajopt::JointJerkIneqCost)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_CONVEX, trajopt::JointPosIneqConstraint)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_CONVEX, trajopt::JointVelIneqConstraint)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_CONVEX, trajopt::JointAccIneqConstraint)->Unit(benchmark::TimeUnit::kNanosecond);
+BENCHMARK_TEMPLATE(BM_INEQ_TERM_CONVEX, trajopt::JointJerkIneqConstraint)->Unit(benchmark::TimeUnit::kNanosecond);
+
+BENCHMARK_MAIN();

--- a/trajopt_utils/cmake/trajopt_macros.cmake
+++ b/trajopt_utils/cmake/trajopt_macros.cmake
@@ -166,3 +166,17 @@ macro(trajopt_add_run_tests_target)
     add_custom_target(run_tests)
   endif()
 endmacro()
+
+# This macro add a custom target that will run the benchmarks after they are finished building.
+# Usage: trajopt_add_run_benchmark_target(benchmark_name)
+# Results are saved to /test/benchmarks/${benchmark_name}_results.json in the build directory
+macro(trajopt_add_run_benchmark_target benchmark_name)
+  if(TRAJOPT_ENABLE_RUN_BENCHMARKING)
+    add_custom_target(run_benchmark_${benchmark_name} ALL
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMAND ./test/benchmarks/${benchmark_name} --benchmark_out_format=json --benchmark_out="./test/benchmarks/${benchmark_name}_results.json")
+  else()
+    add_custom_target(run_benchmark_${benchmark_name})
+  endif()
+  add_dependencies(run_benchmark_${benchmark_name} ${benchmark_name})
+endmacro()


### PR DESCRIPTION
Adds a Google benchmark for the Joint Terms. 

To output to CSV
```
./trajopt_joint_term_benchmark --benchmark_format=csv > trajopt_joint_term_benchmark.csv
```

An example terminal output looks like below. 
```
You can set logging level with TRAJOPT_LOG_THRESH. Valid values: FATAL ERROR WARN INFO DEBUG TRACE. Defaulting to ERROR
Run on (20 X 4100 MHz CPU s)
2020-04-02 11:53:14
***WARNING*** Library was built as DEBUG. Timings may be affected.
---------------------------------------------------------------------------------------------------
Benchmark                                                            Time           CPU Iterations
---------------------------------------------------------------------------------------------------
BM_EQ_TERM_CONSTRUCTION<trajopt::JointPosEqCost>                    11 us         11 us      57705
BM_EQ_TERM_CONSTRUCTION<trajopt::JointVelEqCost>                    15 us         15 us      47277
BM_EQ_TERM_CONSTRUCTION<trajopt::JointAccEqCost>                    18 us         18 us      39831
BM_EQ_TERM_CONSTRUCTION<trajopt::JointJerkEqCost>                   19 us         19 us      36099
BM_EQ_TERM_CONSTRUCTION<trajopt::JointPosEqConstraint>               9 us          9 us      76177
BM_EQ_TERM_CONSTRUCTION<trajopt::JointVelEqConstraint>              12 us         12 us      57024
BM_EQ_TERM_CONSTRUCTION<trajopt::JointAccEqConstraint>              14 us         14 us      51510
BM_EQ_TERM_CONSTRUCTION<trajopt::JointJerkEqConstraint>             14 us         14 us      51142
BM_INEQ_TERM_CONSTRUCTION<trajopt::JointPosIneqCost>                21 us         21 us      32894
BM_INEQ_TERM_CONSTRUCTION<trajopt::JointVelIneqCost>                23 us         23 us      30497
BM_INEQ_TERM_CONSTRUCTION<trajopt::JointAccIneqCost>                24 us         24 us      28853
BM_INEQ_TERM_CONSTRUCTION<trajopt::JointJerkIneqCost>               23 us         23 us      30542
BM_INEQ_TERM_CONSTRUCTION<trajopt::JointPosIneqConstraint>          22 us         22 us      31161
BM_INEQ_TERM_CONSTRUCTION<trajopt::JointVelIneqConstraint>          23 us         23 us      29834
BM_INEQ_TERM_CONSTRUCTION<trajopt::JointAccIneqConstraint>          24 us         24 us      29384
BM_INEQ_TERM_CONSTRUCTION<trajopt::JointJerkIneqConstraint>         23 us         23 us      30592
BM_EQ_TERM_VALUE<trajopt::JointPosEqCost>                          246 ns        246 ns    2824861
BM_EQ_TERM_VALUE<trajopt::JointVelEqCost>                          348 ns        348 ns    2002731
BM_EQ_TERM_VALUE<trajopt::JointAccEqCost>                          393 ns        393 ns    1778067
BM_EQ_TERM_VALUE<trajopt::JointJerkEqCost>                         437 ns        437 ns    1592892
BM_EQ_TERM_VALUE<trajopt::JointPosEqConstraint>                    264 ns        264 ns    2656628
BM_EQ_TERM_VALUE<trajopt::JointVelEqConstraint>                    373 ns        373 ns    1869667
BM_EQ_TERM_VALUE<trajopt::JointAccEqConstraint>                    424 ns        424 ns    1600696
BM_EQ_TERM_VALUE<trajopt::JointJerkEqConstraint>                   467 ns        466 ns    1464800
BM_INEQ_TERM_VALUE<trajopt::JointPosIneqCost>                      415 ns        415 ns    1687491
BM_INEQ_TERM_VALUE<trajopt::JointVelIneqCost>                      484 ns        484 ns    1425588
BM_INEQ_TERM_VALUE<trajopt::JointAccIneqCost>                      539 ns        539 ns    1286543
BM_INEQ_TERM_VALUE<trajopt::JointJerkIneqCost>                     571 ns        571 ns    1165097
BM_INEQ_TERM_VALUE<trajopt::JointPosIneqConstraint>                702 ns        702 ns     978400
BM_INEQ_TERM_VALUE<trajopt::JointVelIneqConstraint>                686 ns        686 ns     993659
BM_INEQ_TERM_VALUE<trajopt::JointAccIneqConstraint>                712 ns        712 ns     974638
BM_INEQ_TERM_VALUE<trajopt::JointJerkIneqConstraint>               712 ns        712 ns     944545
BM_EQ_TERM_CONVEX<trajopt::JointPosEqCost>                         221 ns        221 ns    3140704
BM_EQ_TERM_CONVEX<trajopt::JointVelEqCost>                         428 ns        428 ns    1632900
BM_EQ_TERM_CONVEX<trajopt::JointAccEqCost>                         637 ns        637 ns    1075613
BM_EQ_TERM_CONVEX<trajopt::JointJerkEqCost>                        989 ns        989 ns     693922
BM_EQ_TERM_CONVEX<trajopt::JointPosEqConstraint>                  4466 ns       4466 ns     157288
BM_EQ_TERM_CONVEX<trajopt::JointVelEqConstraint>                  4132 ns       4132 ns     168970
BM_EQ_TERM_CONVEX<trajopt::JointAccEqConstraint>                  3752 ns       3752 ns     186544
BM_EQ_TERM_CONVEX<trajopt::JointJerkEqConstraint>                 2994 ns       2994 ns     236697
BM_INEQ_TERM_CONVEX<trajopt::JointPosIneqCost>                   32226 ns      32223 ns      21027
BM_INEQ_TERM_CONVEX<trajopt::JointVelIneqCost>                   28583 ns      28581 ns      24419
BM_INEQ_TERM_CONVEX<trajopt::JointAccIneqCost>                   25258 ns      25257 ns      28232
BM_INEQ_TERM_CONVEX<trajopt::JointJerkIneqCost>                  21233 ns      21232 ns      33756
BM_INEQ_TERM_CONVEX<trajopt::JointPosIneqConstraint>             21240 ns      21239 ns      33799
BM_INEQ_TERM_CONVEX<trajopt::JointVelIneqConstraint>             23216 ns      23215 ns      32415
BM_INEQ_TERM_CONVEX<trajopt::JointAccIneqConstraint>             22775 ns      22775 ns      32225
BM_INEQ_TERM_CONVEX<trajopt::JointJerkIneqConstraint>            10063 ns      10063 ns      68695

```