### PR TITLE
Add init method to trust region sqp solver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
     - CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DTRAJOPT_ENABLE_TESTING=ON -DTRAJOPT_ENABLE_RUN_TESTING=OFF"
     - ROSDEP_SKIP_KEYS="bullet3 fcl"
     - BUILD_PKGS_WHITELIST="trajopt trajopt_sco trajopt_tools trajopt_utils trajopt_ifopt trajopt_sqp"
-    - AFTER_SCRIPT='catkin test -w $CATKIN_WORKSPACE --no-deps trajopt trajopt_sco'
+    - AFTER_SCRIPT='catkin test -w $CATKIN_WORKSPACE --no-deps trajopt trajopt_ifopt trajopt_sco trajopt_sqp'
     - PKGS_DOWNSTREAM=''
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
     - env: ROS_DISTRO=melodic ROS_REPO=ros-shadow-fixed DOCKER_IMAGE=lharmstrong/tesseract:melodic ROS_PARALLEL_JOBS=-j4 ROS_PARALLEL_TEST_JOBS=-j4
 
 install:
-  - git clone --quiet --depth=1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci
+  - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b legacy
 
 script:
   - .industrial_ci/travis.sh

--- a/trajopt_optimizers/trajopt_sqp/include/trajopt_sqp/trust_region_sqp_solver.h
+++ b/trajopt_optimizers/trajopt_sqp/include/trajopt_sqp/trust_region_sqp_solver.h
@@ -50,6 +50,8 @@ public:
 
   TrustRegionSQPSolver(QPSolver::Ptr qp_solver);
 
+  bool init(ifopt::Problem& nlp);
+
   void Solve(ifopt::Problem& nlp) override;
 
   /**

--- a/trajopt_optimizers/trajopt_sqp/src/trust_region_sqp_solver.cpp
+++ b/trajopt_optimizers/trajopt_sqp/src/trust_region_sqp_solver.cpp
@@ -41,7 +41,7 @@ TrustRegionSQPSolver::TrustRegionSQPSolver(QPSolver::Ptr qp_solver) : qp_solver(
   qp_problem = std::make_shared<QPProblem>();
 }
 
-void TrustRegionSQPSolver::Solve(ifopt::Problem& nlp)
+bool TrustRegionSQPSolver::init(ifopt::Problem& nlp)
 {
   console_bridge::setLogLevel(console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO);
   nlp_ = &nlp;
@@ -52,6 +52,13 @@ void TrustRegionSQPSolver::Solve(ifopt::Problem& nlp)
   results_ = SQPResults(nlp.GetNumberOfOptimizationVariables(), nlp.GetNumberOfConstraints());
   results_.box_size = Eigen::VectorXd::Ones(nlp.GetNumberOfOptimizationVariables()) * params.initial_trust_box_size;
   qp_problem->setBoxSize(results_.box_size);
+  return true;
+}
+
+void TrustRegionSQPSolver::Solve(ifopt::Problem& nlp)
+{
+  // Initialize solver
+  init(nlp);
 
   // ---------------------------
   // Penalty Iteration Loop


### PR DESCRIPTION
We needed some way of initializing when not using the Solve method now that results_ is private.