### PR TITLE
Add Colcon environment hooks

### DIFF
--- a/trajopt/colcon.pkg
+++ b/trajopt/colcon.pkg
@@ -1,0 +1,3 @@
+{
+    "hooks": ["share/trajopt/hook/ament_prefix_path.dsv", "share/trajopt/hook/ros_package_path.dsv"]
+}

--- a/trajopt_ext/osqp/colcon.pkg
+++ b/trajopt_ext/osqp/colcon.pkg
@@ -1,0 +1,3 @@
+{
+    "hooks": ["share/osqp/hook/ament_prefix_path.dsv", "share/osqp/hook/ros_package_path.dsv"]
+}

--- a/trajopt_ext/osqp_eigen/colcon.pkg
+++ b/trajopt_ext/osqp_eigen/colcon.pkg
@@ -1,0 +1,3 @@
+{
+    "hooks": ["share/osqp_eigen/hook/ament_prefix_path.dsv", "share/osqp_eigen/hook/ros_package_path.dsv"]
+}

--- a/trajopt_ext/vhacd/colcon.pkg
+++ b/trajopt_ext/vhacd/colcon.pkg
@@ -1,0 +1,3 @@
+{
+    "hooks": ["share/vhacd/hook/ament_prefix_path.dsv", "share/vhacd/hook/ros_package_path.dsv"]
+}

--- a/trajopt_ifopt/colcon.pkg
+++ b/trajopt_ifopt/colcon.pkg
@@ -1,0 +1,3 @@
+{
+    "hooks": ["share/trajopt_ifopt/hook/ament_prefix_path.dsv", "share/trajopt_ifopt/hook/ros_package_path.dsv"]
+}

--- a/trajopt_optimizers/trajopt_sqp/colcon.pkg
+++ b/trajopt_optimizers/trajopt_sqp/colcon.pkg
@@ -1,0 +1,3 @@
+{
+    "hooks": ["share/trajopt_sqp/hook/ament_prefix_path.dsv", "share/trajopt_sqp/hook/ros_package_path.dsv"]
+}

--- a/trajopt_sco/colcon.pkg
+++ b/trajopt_sco/colcon.pkg
@@ -1,0 +1,3 @@
+{
+    "hooks": ["share/trajopt_sco/hook/ament_prefix_path.dsv", "share/trajopt_sco/hook/ros_package_path.dsv"]
+}

--- a/trajopt_tools/colcon.pkg
+++ b/trajopt_tools/colcon.pkg
@@ -1,0 +1,3 @@
+{
+    "hooks": ["share/trajopt_tools/hook/ament_prefix_path.dsv", "share/trajopt_tools/hook/ros_package_path.dsv"]
+}

--- a/trajopt_utils/cmake/trajopt_macros.cmake
+++ b/trajopt_utils/cmake/trajopt_macros.cmake
@@ -143,6 +143,14 @@ macro(trajopt_configure_package)
     DESTINATION lib/cmake/${PROJECT_NAME})
 
   export(EXPORT ${PROJECT_NAME}-targets NAMESPACE trajopt:: FILE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-targets.cmake)
+
+  # Allows Colcon to find non-Ament packages when using workspace underlays
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} "")
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} DESTINATION share/ament_index/resource_index/packages)
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv "prepend-non-duplicate;AMENT_PREFIX_PATH;")
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv DESTINATION share/${PROJECT_NAME}/hook)
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ros_package_path.dsv "prepend-non-duplicate;ROS_PACKAGE_PATH;")
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ros_package_path.dsv DESTINATION share/${PROJECT_NAME}/hook)
 endmacro()
 
 # This macro call the appropriate gtest function to add a test based on the cmake version

--- a/trajopt_utils/colcon.pkg
+++ b/trajopt_utils/colcon.pkg
@@ -1,0 +1,3 @@
+{
+    "hooks": ["share/trajopt_utils/hook/ament_prefix_path.dsv", "share/trajopt_utils/hook/ros_package_path.dsv"]
+}


### PR DESCRIPTION
Fixes rosdep issues when building trajopt in an extended workspace.