### PR TITLE
readme: link to where we keep trajopt_examples (since #108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ Once `trajopt_ros` is compiled with support for a specific solver, you can selec
 The selection to `AUTO_SOLVER` is the default and automatically picks the best between the available solvers.
 
 ## TrajOpt Examples
-If you're new to TrajOpt, a great place to start is trajopt_examples. This contains a number of examples to get you started. Additionally, there is an industrial training module that covers TrajOpt for a pick and place application. That module can be found [HERE](https://industrial-training-master.readthedocs.io/en/melodic/_source/demo3/index.html).
+If you're new to TrajOpt, a great place to start is [trajopt_examples](https://github.com/ros-industrial-consortium/tesseract_ros/tree/master/tesseract_ros/tesseract_examples/tesseract_ros_examples). This contains a number of examples to get you started.
+This package is no longer part of this repository, but is maintained over at `ros-industrial-consortium/tesseract_ros`.
+
+Additionally, there is an industrial training module that covers TrajOpt for a pick and place application. That module can be found [HERE](https://industrial-training-master.readthedocs.io/en/melodic/_source/demo3/index.html).
 #### Pick and Place
 The pick and place example is great place to start because it shows a complete end to end process using TrajOpt. While the code itself is quite long, this is because it is showing setting up and solving 2 problems (the pick and the place) as well as attaching and detaching objects in Tesseract. It makes use of the Tesseract TrajOpt Planner which simplifies some of the problem setup.
 


### PR DESCRIPTION
As per subject.

Took me some time to find it again, and the readme here seemed to be pointing me to the training exercises.
