### PR TITLE
Improve const-correctness of reference passing.

### DIFF
--- a/trajopt/include/trajopt/collision_terms.hpp
+++ b/trajopt/include/trajopt/collision_terms.hpp
@@ -404,7 +404,7 @@ public:
    * @param dof_vals Joint values set prior to collision checking
    * @param dist_results Contact Results Map
    */
-  void CalcCollisions(const Eigen::Ref<Eigen::VectorXd>& dof_vals, tesseract_collision::ContactResultMap& dist_results);
+  void CalcCollisions(const Eigen::Ref<const Eigen::VectorXd>& dof_vals, tesseract_collision::ContactResultMap& dist_results);
   void Plot(const tesseract_visualization::Visualization::Ptr& plotter, const DblVec& x) override;
   sco::VarVector GetVars() override { return vars0_; }
 
@@ -444,8 +444,8 @@ public:
    * @param dof_vals1 Joint values for state1
    * @param dist_results Contact Results Map
    */
-  void CalcCollisions(const Eigen::Ref<Eigen::VectorXd>& dof_vals0,
-                      const Eigen::Ref<Eigen::VectorXd>& dof_vals1,
+  void CalcCollisions(const Eigen::Ref<const Eigen::VectorXd>& dof_vals0,
+                      const Eigen::Ref<const Eigen::VectorXd>& dof_vals1,
                       tesseract_collision::ContactResultMap& dist_results);
   void Plot(const tesseract_visualization::Visualization::Ptr& plotter, const DblVec& x) override;
   sco::VarVector GetVars() override { return concat(vars0_, vars1_); }
@@ -486,8 +486,8 @@ public:
    * @param dof_vals1 Joint values for state1
    * @param dist_results Contact Results Map
    */
-  void CalcCollisions(const Eigen::Ref<Eigen::VectorXd>& dof_vals0,
-                      const Eigen::Ref<Eigen::VectorXd>& dof_vals1,
+  void CalcCollisions(const Eigen::Ref<const Eigen::VectorXd>& dof_vals0,
+                      const Eigen::Ref<const Eigen::VectorXd>& dof_vals1,
                       tesseract_collision::ContactResultMap& dist_results);
   void Plot(const tesseract_visualization::Visualization::Ptr& plotter, const DblVec& x) override;
   sco::VarVector GetVars() override { return concat(vars0_, vars1_); }

--- a/trajopt/src/collision_terms.cpp
+++ b/trajopt/src/collision_terms.cpp
@@ -953,7 +953,7 @@ void SingleTimestepCollisionEvaluator::CalcCollisions(const DblVec& x,
   CalcCollisions(joint_vals, dist_results);
 }
 
-void SingleTimestepCollisionEvaluator::CalcCollisions(const Eigen::Ref<Eigen::VectorXd>& dof_vals,
+void SingleTimestepCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::VectorXd>& dof_vals,
                                                       tesseract_collision::ContactResultMap& dist_results)
 {
   tesseract_environment::EnvState::Ptr state = get_state_fn_(manip_->getJointNames(), dof_vals);
@@ -1123,8 +1123,8 @@ void DiscreteCollisionEvaluator::CalcCollisions(const DblVec& x, tesseract_colli
   CalcCollisions(s0, s1, dist_results);
 }
 
-void DiscreteCollisionEvaluator::CalcCollisions(const Eigen::Ref<Eigen::VectorXd>& dof_vals0,
-                                                const Eigen::Ref<Eigen::VectorXd>& dof_vals1,
+void DiscreteCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::VectorXd>& dof_vals0,
+                                                const Eigen::Ref<const Eigen::VectorXd>& dof_vals1,
                                                 tesseract_collision::ContactResultMap& dist_results)
 {
   // The first step is to see if the distance between two states is larger than the longest valid segment. If larger
@@ -1358,8 +1358,8 @@ void CastCollisionEvaluator::CalcCollisions(const DblVec& x, tesseract_collision
   CalcCollisions(s0, s1, dist_results);
 }
 
-void CastCollisionEvaluator::CalcCollisions(const Eigen::Ref<Eigen::VectorXd>& dof_vals0,
-                                            const Eigen::Ref<Eigen::VectorXd>& dof_vals1,
+void CastCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::VectorXd>& dof_vals0,
+                                            const Eigen::Ref<const Eigen::VectorXd>& dof_vals1,
                                             tesseract_collision::ContactResultMap& dist_results)
 {
   // The first step is to see if the distance between two states is larger than the longest valid segment. If larger

--- a/trajopt_ifopt/include/trajopt_ifopt/constraints/cartesian_position_constraint.h
+++ b/trajopt_ifopt/include/trajopt_ifopt/constraints/cartesian_position_constraint.h
@@ -99,7 +99,7 @@ public:
    * @return Error of FK solution from target, size 6. The first 3 terms are associated with position and the last 3 are
    * associated with orientation.
    */
-  Eigen::VectorXd CalcValues(const Eigen::Ref<Eigen::VectorXd>& joint_vals) const;
+  Eigen::VectorXd CalcValues(const Eigen::Ref<const Eigen::VectorXd>& joint_vals) const;
   /**
    * @brief Returns the values associated with the constraint. In this case that is the concatenated joint values
    * associated with each of the joint positions should be n_dof_ * n_vars_ long
@@ -119,7 +119,7 @@ public:
    * @brief Fills the jacobian block associated with the constraint
    * @param jac_block Block of the overall jacobian associated with these constraints
    */
-  void CalcJacobianBlock(const Eigen::Ref<Eigen::VectorXd>& joint_vals, Jacobian& jac_block) const;
+  void CalcJacobianBlock(const Eigen::Ref<const Eigen::VectorXd>& joint_vals, Jacobian& jac_block) const;
   /**
    * @brief Fills the jacobian block associated with the given var_set.
    * @param var_set Name of the var_set to which the jac_block is associated

--- a/trajopt_ifopt/include/trajopt_ifopt/constraints/collision_constraint.h
+++ b/trajopt_ifopt/include/trajopt_ifopt/constraints/collision_constraint.h
@@ -50,7 +50,7 @@ public:
                            const std::string& name = "Collision");
 
   /** @brief Calculates the values associated with the constraint */
-  Eigen::VectorXd CalcValues(const Eigen::Ref<Eigen::VectorXd>& joint_vals) const;
+  Eigen::VectorXd CalcValues(const Eigen::Ref<const Eigen::VectorXd>& joint_vals) const;
   /**
    * @brief Returns the values associated with the constraint.
    * @return
@@ -73,7 +73,7 @@ public:
    * @brief Fills the jacobian block associated with the constraint
    * @param jac_block Block of the overall jacobian associated with these constraints
    */
-  void CalcJacobianBlock(const Eigen::Ref<Eigen::VectorXd>& joint_vals, Jacobian& jac_block) const;
+  void CalcJacobianBlock(const Eigen::Ref<const Eigen::VectorXd>& joint_vals, Jacobian& jac_block) const;
   /**
    * @brief Fills the jacobian block associated with the given var_set.
    * @param var_set Name of the var_set to which the jac_block is associated

--- a/trajopt_ifopt/include/trajopt_ifopt/constraints/inverse_kinematics_constraint.h
+++ b/trajopt_ifopt/include/trajopt_ifopt/constraints/inverse_kinematics_constraint.h
@@ -112,8 +112,8 @@ public:
    * @param seed_joint_position Joint values used as the seed when calculating IK
    * @return Distance of each joint from the IK solution
    */
-  Eigen::VectorXd CalcValues(const Eigen::Ref<Eigen::VectorXd>& joint_vals,
-                             const Eigen::Ref<Eigen::VectorXd>& seed_joint_position) const;
+  Eigen::VectorXd CalcValues(const Eigen::Ref<const Eigen::VectorXd>& joint_vals,
+                             const Eigen::Ref<const Eigen::VectorXd>& seed_joint_position) const;
   /**
    * @brief Returns the values associated with the constraint. This is the joint distance from the target joint position
    * (size n_dof_)
@@ -134,7 +134,7 @@ public:
    * @brief Fills the jacobian block associated with the constraint
    * @param jac_block Block of the overall jacobian associated with these constraints
    */
-  void CalcJacobianBlock(const Eigen::Ref<Eigen::VectorXd>& joint_vals, Jacobian& jac_block) const;
+  void CalcJacobianBlock(const Eigen::Ref<const Eigen::VectorXd>& joint_vals, Jacobian& jac_block) const;
   /**
    * @brief Fills the jacobian block associated with the given var_set.
    *

--- a/trajopt_ifopt/include/trajopt_ifopt/utils/ifopt_utils.h
+++ b/trajopt_ifopt/include/trajopt_ifopt/utils/ifopt_utils.h
@@ -39,7 +39,7 @@ namespace trajopt
  * @param limits MatrixX2d of bounds. Column 0 will be lower bound. Column 1 will be upper bound
  * @return Vector of ifopt::Bounds
  */
-inline std::vector<ifopt::Bounds> toBounds(const Eigen::Ref<Eigen::MatrixX2d>& limits)
+inline std::vector<ifopt::Bounds> toBounds(const Eigen::Ref<const Eigen::MatrixX2d>& limits)
 {
   std::vector<ifopt::Bounds> bounds;
   for (Eigen::Index i = 0; i < limits.rows(); i++)
@@ -54,8 +54,8 @@ inline std::vector<ifopt::Bounds> toBounds(const Eigen::Ref<Eigen::MatrixX2d>& l
  * @param steps Length of the returned vector
  * @return A vector of Eigen vectors interpolated from start to end
  */
-inline std::vector<Eigen::VectorXd> interpolate(const Eigen::Ref<Eigen::VectorXd>& start,
-                                                const Eigen::Ref<Eigen::VectorXd>& end,
+inline std::vector<Eigen::VectorXd> interpolate(const Eigen::Ref<const Eigen::VectorXd>& start,
+                                                const Eigen::Ref<const Eigen::VectorXd>& end,
                                                 Eigen::Index steps)
 {
   assert(start.size() == end.size());
@@ -76,7 +76,7 @@ inline std::vector<Eigen::VectorXd> interpolate(const Eigen::Ref<Eigen::VectorXd
  * @param bounds Bounds on that vector
  * @return Output vector. If input is outside a bound, force it to the boundary
  */
-inline Eigen::VectorXd getClosestValidPoint(const Eigen::Ref<Eigen::VectorXd>& input, std::vector<ifopt::Bounds> bounds)
+inline Eigen::VectorXd getClosestValidPoint(const Eigen::Ref<const Eigen::VectorXd>& input, std::vector<ifopt::Bounds> bounds)
 {
   // Convert Bounds to VectorXds
   Eigen::VectorXd bound_lower(static_cast<Eigen::Index>(bounds.size()));

--- a/trajopt_ifopt/include/trajopt_ifopt/utils/numeric_differentiation.h
+++ b/trajopt_ifopt/include/trajopt_ifopt/utils/numeric_differentiation.h
@@ -34,17 +34,17 @@ TRAJOPT_IGNORE_WARNINGS_POP
 
 namespace trajopt
 {
-using ErrorCalculator = std::function<Eigen::VectorXd(const Eigen::Ref<Eigen::VectorXd>&)>;
+using ErrorCalculator = std::function<Eigen::VectorXd(const Eigen::Ref<const Eigen::VectorXd>&)>;
 using Jacobian = Eigen::SparseMatrix<double, Eigen::RowMajor>;
 
 /**
  * @brief Calculates the jacobian of the given error calculator using forward numeric differentiation
- * @param f Input error calculator, Eigen::VectorXd(const Eigen::Ref<Eigen::VectorXd>&)
+ * @param f Input error calculator, Eigen::VectorXd(const Eigen::Ref<const Eigen::VectorXd>&)
  * @param x Point about which f is calculated
  * @param epsilon Amount x is perturbed
  * @return The resulting jacobian. If f(x) = y, jac.size = [y.size(), x.size()]
  */
-inline Jacobian calcForwardNumJac(const ErrorCalculator& f, const Eigen::Ref<Eigen::VectorXd>& x, double epsilon)
+inline Jacobian calcForwardNumJac(const ErrorCalculator& f, const Eigen::Ref<const Eigen::VectorXd>& x, double epsilon)
 {
   Eigen::VectorXd y = f(x);
   Eigen::MatrixXd out(y.size(), x.size());

--- a/trajopt_ifopt/include/trajopt_ifopt/variable_sets/joint_position_variable.h
+++ b/trajopt_ifopt/include/trajopt_ifopt/variable_sets/joint_position_variable.h
@@ -83,7 +83,7 @@ public:
    * second column being upper bound
    * @param bounds Columns 1/2 are lower/upper bounds. You probably will get this from forward_kinematics->getLimits()
    */
-  void SetBounds(const Eigen::Ref<Eigen::MatrixX2d>& bounds) { bounds_ = toBounds(bounds); }
+  void SetBounds(const Eigen::Ref<const Eigen::MatrixX2d>& bounds) { bounds_ = toBounds(bounds); }
 
   /**
    * @brief Get the joint names associated with this variable set

--- a/trajopt_ifopt/src/cartesian_position_constraint.cpp
+++ b/trajopt_ifopt/src/cartesian_position_constraint.cpp
@@ -51,7 +51,7 @@ CartPosConstraint::CartPosConstraint(const Eigen::Isometry3d& target_pose,
   bounds_ = std::vector<ifopt::Bounds>(6, ifopt::BoundZero);
 }
 
-Eigen::VectorXd CartPosConstraint::CalcValues(const Eigen::Ref<Eigen::VectorXd>& joint_vals) const
+Eigen::VectorXd CartPosConstraint::CalcValues(const Eigen::Ref<const Eigen::VectorXd>& joint_vals) const
 {
   Eigen::Isometry3d new_pose;
   kinematic_info_->manip->calcFwdKin(new_pose, joint_vals, kinematic_info_->kin_link->link_name);
@@ -79,11 +79,11 @@ void CartPosConstraint::SetBounds(const std::vector<ifopt::Bounds>& bounds)
   bounds_ = bounds;
 }
 
-void CartPosConstraint::CalcJacobianBlock(const Eigen::Ref<Eigen::VectorXd>& joint_vals, Jacobian& jac_block) const
+void CartPosConstraint::CalcJacobianBlock(const Eigen::Ref<const Eigen::VectorXd>& joint_vals, Jacobian& jac_block) const
 {
   if (use_numeric_differentiation)
   {
-    auto error_calculator = [&](const Eigen::Ref<Eigen::VectorXd>& x) { return this->CalcValues(x); };
+    auto error_calculator = [&](const Eigen::Ref<const Eigen::VectorXd>& x) { return this->CalcValues(x); };
     Jacobian jac0(6, n_dof_);
     jac0 = calcForwardNumJac(error_calculator, joint_vals, 1e-5);
 

--- a/trajopt_ifopt/src/collision_constraint.cpp
+++ b/trajopt_ifopt/src/collision_constraint.cpp
@@ -48,7 +48,7 @@ CollisionConstraintIfopt::CollisionConstraintIfopt(SingleTimestepCollisionEvalua
   bounds_ = std::vector<ifopt::Bounds>(1, ifopt::BoundSmallerZero);
 }
 
-Eigen::VectorXd CollisionConstraintIfopt::CalcValues(const Eigen::Ref<Eigen::VectorXd>& joint_vals) const
+Eigen::VectorXd CollisionConstraintIfopt::CalcValues(const Eigen::Ref<const Eigen::VectorXd>& joint_vals) const
 {
   Eigen::VectorXd err = Eigen::VectorXd::Zero(1);
 
@@ -89,7 +89,7 @@ void CollisionConstraintIfopt::SetBounds(const std::vector<ifopt::Bounds>& bound
   bounds_ = bounds;
 }
 
-void CollisionConstraintIfopt::CalcJacobianBlock(const Eigen::Ref<Eigen::VectorXd>& joint_vals,
+void CollisionConstraintIfopt::CalcJacobianBlock(const Eigen::Ref<const Eigen::VectorXd>& joint_vals,
                                                  Jacobian& jac_block) const
 {
   // Reserve enough room in the sparse matrix

--- a/trajopt_ifopt/src/inverse_kinematics_constraint.cpp
+++ b/trajopt_ifopt/src/inverse_kinematics_constraint.cpp
@@ -52,8 +52,8 @@ InverseKinematicsConstraint::InverseKinematicsConstraint(const Eigen::Isometry3d
   bounds_ = std::vector<ifopt::Bounds>(static_cast<std::size_t>(n_dof_), ifopt::BoundZero);
 }
 
-Eigen::VectorXd InverseKinematicsConstraint::CalcValues(const Eigen::Ref<Eigen::VectorXd>& joint_vals,
-                                                        const Eigen::Ref<Eigen::VectorXd>& seed_joint_position) const
+Eigen::VectorXd InverseKinematicsConstraint::CalcValues(const Eigen::Ref<const Eigen::VectorXd>& joint_vals,
+                                                        const Eigen::Ref<const Eigen::VectorXd>& seed_joint_position) const
 {
   // Get joint position using IK and the seed variable
   Eigen::VectorXd target_joint_position;

--- a/trajopt_ifopt/test/cartesian_position_constraint_unit.cpp
+++ b/trajopt_ifopt/test/cartesian_position_constraint_unit.cpp
@@ -146,7 +146,7 @@ TEST_F(CartesianPositionConstraintUnit, FillJacobian)  // NOLINT
     nlp.SetVariables(joint_position_mod.data());
 
     // Calculate jacobian numerically
-    auto error_calculator = [&](const Eigen::Ref<Eigen::VectorXd>& x) { return constraint->CalcValues(x); };
+    auto error_calculator = [&](const Eigen::Ref<const Eigen::VectorXd>& x) { return constraint->CalcValues(x); };
     trajopt::Jacobian num_jac_block = trajopt::calcForwardNumJac(error_calculator, joint_position_mod, 1e-4);
 
     // Compare to constraint jacobian

--- a/trajopt_ifopt/test/inverse_kinematics_constraint_unit.cpp
+++ b/trajopt_ifopt/test/inverse_kinematics_constraint_unit.cpp
@@ -106,7 +106,7 @@ TEST_F(InverseKinematicsConstraintUnit, GetValue)  // NOLINT
       EXPECT_EQ(jac_block.coeff(i, i), -1.0);
 
     // Check against numeric differentiation
-    auto error_calculator = [&](const Eigen::Ref<Eigen::VectorXd>& x) {
+    auto error_calculator = [&](const Eigen::Ref<const Eigen::VectorXd>& x) {
       return constraint->CalcValues(x, joint_position_single);
     };
     trajopt::Jacobian num_jac_block = trajopt::calcForwardNumJac(error_calculator, joint_position_single, 1e-4);

--- a/trajopt_optimizers/trajopt_sqp/include/trajopt_sqp/qp_problem.h
+++ b/trajopt_optimizers/trajopt_sqp/include/trajopt_sqp/qp_problem.h
@@ -70,14 +70,14 @@ public:
   /** @brief Evaluates the cost of the convexified function (ie using the stored gradient and hessian) at var_vals
    * @param var_vals Point at which the convex cost is calculated. Should be size num_qp_vars
    */
-  double evaluateTotalConvexCost(const Eigen::Ref<Eigen::VectorXd>& var_vals);
+  double evaluateTotalConvexCost(const Eigen::Ref<const Eigen::VectorXd>& var_vals);
   /** @brief TODO: This is unimplemented, but it will return the cost associated with each of the costs. Note this will
    * be relatively computationally expensive, as we will have to loop through all the cost components in the problem and
    * calculate their values manually.
    * @param var_vals Point at which the convex cost is calculated. Should be size num_qp_vars
    * @return Cost associated with each cost term in the problem (for debugging)
    */
-  Eigen::VectorXd evaluateConvexCosts(const Eigen::Ref<Eigen::VectorXd>& var_vals);
+  Eigen::VectorXd evaluateConvexCosts(const Eigen::Ref<const Eigen::VectorXd>& var_vals);
 
   /**
    * @brief get the current NLP constraint violations. Values > 0 are violations

--- a/trajopt_optimizers/trajopt_sqp/src/qp_problem.cpp
+++ b/trajopt_optimizers/trajopt_sqp/src/qp_problem.cpp
@@ -264,14 +264,14 @@ void QPProblem::updateSlackVariableBounds()
   }
 }
 
-double QPProblem::evaluateTotalConvexCost(const Eigen::Ref<Eigen::VectorXd>& var_vals)
+double QPProblem::evaluateTotalConvexCost(const Eigen::Ref<const Eigen::VectorXd>& var_vals)
 {
   double result_quad = var_vals.transpose() * hessian_ * var_vals;
   double result_lin = gradient_.transpose() * var_vals;
   return result_quad + result_lin;
 }
 
-Eigen::VectorXd QPProblem::evaluateConvexCosts(const Eigen::Ref<Eigen::VectorXd>& /*var_vals*/)
+Eigen::VectorXd QPProblem::evaluateConvexCosts(const Eigen::Ref<const Eigen::VectorXd>& /*var_vals*/)
 {
   return Eigen::VectorXd();
 }


### PR DESCRIPTION
This fix allows const-correctness in downstream projects, for constructions like
```
const Eigen::VectorXd home_position = ...
const auto initial_states = trajopt::interpolate(home_position, ...
```

One potential concern would be non-contiguous memory silently converting to a copy rather than failing to compile. From https://eigen.tuxfamily.org/dox/classEigen_1_1Ref.html: "In the const case, if the input expression does not match the above requirement, then it is evaluated into a temporary before being passed to the function." I didn't see anywhere that would be a concern, and the copy might be faster in some contexts due to improved locality/vectorization, but it's something to be aware of.