### PR TITLE
Rename `dofs_fixed` parameter

### DIFF
--- a/trajopt/include/trajopt/collision_terms.hpp
+++ b/trajopt/include/trajopt/collision_terms.hpp
@@ -404,7 +404,8 @@ public:
    * @param dof_vals Joint values set prior to collision checking
    * @param dist_results Contact Results Map
    */
-  void CalcCollisions(const Eigen::Ref<const Eigen::VectorXd>& dof_vals, tesseract_collision::ContactResultMap& dist_results);
+  void CalcCollisions(const Eigen::Ref<const Eigen::VectorXd>& dof_vals,
+                      tesseract_collision::ContactResultMap& dist_results);
   void Plot(const tesseract_visualization::Visualization::Ptr& plotter, const DblVec& x) override;
   sco::VarVector GetVars() override { return vars0_; }
 

--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -101,7 +101,7 @@ struct BasicInfo
   /** @brief Number of time steps (rows) in the optimization matrix */
   int n_steps;
   std::string manip;
-  std::string robot;             // optional
+  std::string robot;  // optional
   /** @brief Timesteps at which to apply a fixed joint constraint */
   IntVec fixed_timesteps;
   sco::ModelType convex_solver;  // which convex solver to use

--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -102,7 +102,8 @@ struct BasicInfo
   int n_steps;
   std::string manip;
   std::string robot;             // optional
-  IntVec dofs_fixed;             // optional
+  /** @brief Timesteps at which to apply a fixed joint constraint */
+  IntVec fixed_timesteps;
   sco::ModelType convex_solver;  // which convex solver to use
 
   /** @brief If true, the last column in the optimization matrix will be 1/dt */

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -1944,8 +1944,8 @@ void AvoidSingularityTermInfo::hatch(TrajOptProb& prob)
     const std::string idx_name = name + "_" + std::to_string(i);
     if (term_type & TT_COST)
     {
-      prob.addCost(sco::Cost::Ptr(
-          new TrajOptCostFromErrFunc(f, dfdx, prob.GetVarRow(i, 0, n_dof), util::toVectorXd(coeffs), sco::ABS, idx_name)));
+      prob.addCost(sco::Cost::Ptr(new TrajOptCostFromErrFunc(
+          f, dfdx, prob.GetVarRow(i, 0, n_dof), util::toVectorXd(coeffs), sco::ABS, idx_name)));
     }
     else if (term_type & TT_CNT)
     {

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -1941,15 +1941,16 @@ void AvoidSingularityTermInfo::hatch(TrajOptProb& prob)
   // Apply error calculator as either cost or constraint
   for (int i = first_step; i <= last_step; ++i)
   {
+    const std::string idx_name = name + "_" + std::to_string(i);
     if (term_type & TT_COST)
     {
       prob.addCost(sco::Cost::Ptr(
-          new TrajOptCostFromErrFunc(f, dfdx, prob.GetVarRow(i, 0, n_dof), util::toVectorXd(coeffs), sco::ABS, name)));
+          new TrajOptCostFromErrFunc(f, dfdx, prob.GetVarRow(i, 0, n_dof), util::toVectorXd(coeffs), sco::ABS, idx_name)));
     }
     else if (term_type & TT_CNT)
     {
       prob.addConstraint(sco::Constraint::Ptr(new TrajOptConstraintFromErrFunc(
-          f, dfdx, prob.GetVarRow(i, 0, n_dof), util::toVectorXd(coeffs), sco::INEQ, name)));
+          f, dfdx, prob.GetVarRow(i, 0, n_dof), util::toVectorXd(coeffs), sco::INEQ, idx_name)));
     }
     else
     {

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -114,7 +114,7 @@ void ProblemConstructionInfo::readBasicInfo(const Json::Value& v)
   json_marshal::childFromJson(v, basic_info.n_steps, "n_steps");
   json_marshal::childFromJson(v, basic_info.manip, "manip");
   json_marshal::childFromJson(v, basic_info.robot, "robot", std::string(""));
-  json_marshal::childFromJson(v, basic_info.dofs_fixed, "dofs_fixed", IntVec());
+  json_marshal::childFromJson(v, basic_info.fixed_timesteps, "fixed_timesteps", IntVec());
   json_marshal::childFromJson(v, basic_info.convex_solver, "convex_solver", basic_info.convex_solver);
   json_marshal::childFromJson(v, basic_info.dt_lower_lim, "dt_lower_lim", 1.0);
   json_marshal::childFromJson(v, basic_info.dt_upper_lim, "dt_upper_lim", 1.0);
@@ -493,10 +493,10 @@ TrajOptProb::Ptr ConstructProblem(const ProblemConstructionInfo& pci)
     }
   }
 
-  // Apply constraint to each fixed dof to its initial value for all timesteps (freeze that column)
-  if (!bi.dofs_fixed.empty())
+  // Apply a constraint to each fixed timestep to set the variables of that timestep equal to their initial values
+  if (!bi.fixed_timesteps.empty())
   {
-    for (const int& dof_ind : bi.dofs_fixed)
+    for (const int& dof_ind : bi.fixed_timesteps)
     {
       for (int i = 1; i < prob->GetNumSteps(); ++i)
       {

--- a/trajopt_ifopt/include/trajopt_ifopt/utils/ifopt_utils.h
+++ b/trajopt_ifopt/include/trajopt_ifopt/utils/ifopt_utils.h
@@ -76,7 +76,8 @@ inline std::vector<Eigen::VectorXd> interpolate(const Eigen::Ref<const Eigen::Ve
  * @param bounds Bounds on that vector
  * @return Output vector. If input is outside a bound, force it to the boundary
  */
-inline Eigen::VectorXd getClosestValidPoint(const Eigen::Ref<const Eigen::VectorXd>& input, std::vector<ifopt::Bounds> bounds)
+inline Eigen::VectorXd getClosestValidPoint(const Eigen::Ref<const Eigen::VectorXd>& input,
+                                            std::vector<ifopt::Bounds> bounds)
 {
   // Convert Bounds to VectorXds
   Eigen::VectorXd bound_lower(static_cast<Eigen::Index>(bounds.size()));

--- a/trajopt_ifopt/src/cartesian_position_constraint.cpp
+++ b/trajopt_ifopt/src/cartesian_position_constraint.cpp
@@ -79,7 +79,8 @@ void CartPosConstraint::SetBounds(const std::vector<ifopt::Bounds>& bounds)
   bounds_ = bounds;
 }
 
-void CartPosConstraint::CalcJacobianBlock(const Eigen::Ref<const Eigen::VectorXd>& joint_vals, Jacobian& jac_block) const
+void CartPosConstraint::CalcJacobianBlock(const Eigen::Ref<const Eigen::VectorXd>& joint_vals,
+                                          Jacobian& jac_block) const
 {
   if (use_numeric_differentiation)
   {

--- a/trajopt_ifopt/src/inverse_kinematics_constraint.cpp
+++ b/trajopt_ifopt/src/inverse_kinematics_constraint.cpp
@@ -52,8 +52,9 @@ InverseKinematicsConstraint::InverseKinematicsConstraint(const Eigen::Isometry3d
   bounds_ = std::vector<ifopt::Bounds>(static_cast<std::size_t>(n_dof_), ifopt::BoundZero);
 }
 
-Eigen::VectorXd InverseKinematicsConstraint::CalcValues(const Eigen::Ref<const Eigen::VectorXd>& joint_vals,
-                                                        const Eigen::Ref<const Eigen::VectorXd>& seed_joint_position) const
+Eigen::VectorXd
+InverseKinematicsConstraint::CalcValues(const Eigen::Ref<const Eigen::VectorXd>& joint_vals,
+                                        const Eigen::Ref<const Eigen::VectorXd>& seed_joint_position) const
 {
   // Get joint position using IK and the seed variable
   Eigen::VectorXd target_joint_position;


### PR DESCRIPTION
This PR changes the name of the `dofs_fixed` parameter to `fixed_timesteps` to more accurately represent its function. This variable is used [here](https://github.com/ros-industrial-consortium/trajopt_ros/blob/b84e4ae30fa658d2911f3e375bb6009dd8ba7084/trajopt/src/problem_description.cpp#L496-L507) constrain all of the optimization variables in each specified time step to their initial values.

This PR also updates the name of the avoid singularity cost that is printed to the terminal during optimization