### PR TITLE
Remove checkJoints check no longer needed

### DIFF
--- a/trajopt/src/kinematic_terms.cpp
+++ b/trajopt/src/kinematic_terms.cpp
@@ -474,12 +474,6 @@ MatrixXd AvoidSingularityJacCalculator::jacobianPartialDerivative(const VectorXd
   double eps = eps_;
   joints(jntIdx) += eps;
 
-  if (!fwd_kin_->checkJoints(joints))
-  {
-    eps = -eps;
-    joints(jntIdx) += 2 * eps;
-  }
-
   MatrixXd jacobian_increment = fwd_kin_->calcJacobian(joints, link_name_);
   return (jacobian_increment - jacobian) / eps;
 }


### PR DESCRIPTION
A while back we updated kinematics so that forward and inverse would still calculated the results even if the joint values are outside the joint limits for the purpose of numerically calculated the jacobian. This check is no longer needed.