### PR TITLE
Fix trajopt_ifopt inverse kinematics constraint unit test

### DIFF
--- a/trajopt_ext/osqp_eigen/CMakeLists.txt
+++ b/trajopt_ext/osqp_eigen/CMakeLists.txt
@@ -9,8 +9,8 @@ if (NOT ${OsqpEigen_FOUND})
   include(ExternalProject)  
 
   ExternalProject_Add(osqp_eigen
-    GIT_REPOSITORY    https://github.com/mpowelson/osqp-eigen
-    GIT_TAG           trajopt_xenial
+    GIT_REPOSITORY    https://github.com/robotology/osqp-eigen
+    GIT_TAG           v0.6.3
     SOURCE_DIR        ${CMAKE_BINARY_DIR}/../trajopt_ext/osqp_eigen-src
     BINARY_DIR        ${CMAKE_BINARY_DIR}/../trajopt_ext/osqp_eigen-build
     CMAKE_CACHE_ARGS

--- a/trajopt_ifopt/src/inverse_kinematics_constraint.cpp
+++ b/trajopt_ifopt/src/inverse_kinematics_constraint.cpp
@@ -59,6 +59,7 @@ InverseKinematicsConstraint::CalcValues(const Eigen::Ref<const Eigen::VectorXd>&
   // Get joint position using IK and the seed variable
   tesseract_kinematics::IKSolutions target_joint_position =
       kinematic_info_->inverse_kinematics->calcInvKin(target_pose_, seed_joint_position);
+  assert(!target_joint_position.empty());
 
   // Calculate joint error
   Eigen::VectorXd error = Eigen::VectorXd::Zero(joint_vals.rows());

--- a/trajopt_ifopt/test/inverse_kinematics_constraint_unit.cpp
+++ b/trajopt_ifopt/test/inverse_kinematics_constraint_unit.cpp
@@ -79,12 +79,12 @@ TEST_F(InverseKinematicsConstraintUnit, GetValue)  // NOLINT
   CONSOLE_BRIDGE_logDebug("InverseKinematicsConstraintUnit, GetValue");
 
   // Run FK to get target pose
-  Eigen::VectorXd joint_position_single = Eigen::VectorXd::Ones(forward_kinematics->numJoints());
+  Eigen::VectorXd joint_position_single = Eigen::VectorXd::Zero(forward_kinematics->numJoints());
   auto target_pose = forward_kinematics->calcFwdKin(joint_position_single);
   constraint->SetTargetPose(target_pose);
 
   // Set the joints to that joint position
-  Eigen::VectorXd joint_position = Eigen::VectorXd::Ones(n_dof * 2);
+  Eigen::VectorXd joint_position = Eigen::VectorXd::Zero(n_dof * 2);
   nlp.SetVariables(joint_position.data());
 
   // Get the value (distance from IK position)


### PR DESCRIPTION
The original unit test was setting the seed outside the joint limits.